### PR TITLE
`//> using $dep` becomes `//> using lib $dep`...

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ println("Hello!")
 ```
 
 
-Dependencies can be added via `//> using` syntax as in scala-cli: test-dependencies.sc
+Dependencies can be added via `//> using lib` syntax as in scala-cli: test-dependencies.sc
 ```scala
-//> using com.michaelpollmeier:versionsort:1.0.7
+//> using lib com.michaelpollmeier:versionsort:1.0.7
 
 val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
 assert(compareResult == 1,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Note: this currently depends on a [slightly patched](https://github.com/mpollmei
 
 Motivation: scala-repl-pp fills a gap between the standard Scala3 REPL, Ammonite and scala-cli.
 
+Note: this currently depends on a dotty fork, which has since been [merged](https://github.com/lampepfl/dotty/pull/16276) into dotty upstream, i.e. we'll be able to depend on the regular dotty release from 3.2.2 on :tada:
+
 ### Why use scala-repl-pp over the regular Scala REPL?
 * add runtime dependencies on startup with maven coordinates - automatically handles all downstream dependencies via [coursier](https://get-coursier.io/)
 * pretty printing via [pprint](https://com-lihaoyi.github.io/PPrint/)
@@ -29,9 +31,13 @@ sbt stage
 cd target/universal/stage/bin/
 ```
 
-### REPL
+Generally speaking, `--help` is your friend!
 ```
 ./scala-repl-pp --help
+```
+
+### REPL
+```
 ./scala-repl-pp --prompt=myprompt --greeting='hey there!' --onExitCode='println("see ya!")'
 
 ./scala-repl-pp --predefCode='def foo = 42'
@@ -45,7 +51,8 @@ val res0: Int = 1
 
 ### Scripting
 
-Simple "Hello world" script: test-simple.sc
+#### Simple "Hello world" script
+test-simple.sc
 ```scala
 println("Hello!")
 ```
@@ -54,8 +61,36 @@ println("Hello!")
 ./scala-repl-pp --script test-simple.sc
 ```
 
+#### Predef code
+test-predef.sc
+```scala
+println(foo)
+```
 
-Dependencies can be added via `//> using lib` syntax as in scala-cli: test-dependencies.sc
+```bash
+./scala-repl-pp --script test-predef.sc --predefCode 'val foo = "Hello, predef!"'
+```
+
+
+#### Predef file(s)
+test-predef.sc
+```scala
+println(foo)
+```
+
+test-predef-file.sc
+```scala
+val foo = "Hello, predef file"
+```
+
+```bash
+./scala-repl-pp --script test-predef.sc --timesiles test-predef-file.sc
+```
+
+#### Dependencies
+Dependencies can be added via `//> using lib` syntax as in scala-cli: 
+
+test-dependencies.sc:
 ```scala
 //> using lib com.michaelpollmeier:versionsort:1.0.7
 
@@ -68,8 +103,10 @@ assert(compareResult == 1,
 ./scala-repl-pp --script test-dependencies.sc
 ```
 
+Note: this also works with `using` directives in your predef code
 
-@main entrypoints: test-main.sc
+#### @main entrypoints
+test-main.sc
 ```scala
 @main def main() = println("Hello, world!")
 ```
@@ -78,8 +115,19 @@ assert(compareResult == 1,
 ./scala-repl-pp --script test-main.sc
 ```
 
+#### multiple @main entrypoints: test-main-multiple.sc
+```scala
+@main def foo() = println("foo!")
+@main def bar() = println("bar!")
+```
 
-@main entrypoint with named parameters: test-main-withargs.sc
+```bash
+./scala-repl-pp --script test-main-multiple.sc --command=foo
+```
+
+
+#### named parameters
+test-main-withargs.sc
 ```scala
 @main def main(name: String) = {
   println(s"Hello, $name!")
@@ -88,18 +136,6 @@ assert(compareResult == 1,
 
 ```bash
 ./scala-repl-pp --script test-main-withargs.sc --params name=Michael
-```
-
-
-
-multiple @main entrypoints: test-main-multiple.sc
-```scala
-@main def foo() = println("foo!")
-@main def bar() = println("bar!")
-```
-
-```bash
-./scala-repl-pp --script test-main-multiple.sc --command=foo
 ```
 
 

--- a/src/main/scala/replpp/ReplDriver.scala
+++ b/src/main/scala/replpp/ReplDriver.scala
@@ -48,6 +48,8 @@ class ReplDriver(args: Array[String],
       given Context = state.context
       try {
         val line = terminal.readLine(completer)
+        if (line.trim.startsWith(ScriptRunner.UsingLibDirective))
+          out.println(s"warning: `using lib` directive does not work as input in interactive REPL - please pass it via predef code or `--dependency` list instead")
         ParseResult(line)(using state)
       } catch {
         case _: EndOfFileException => // Ctrl+D

--- a/src/main/scala/replpp/ScriptRunner.scala
+++ b/src/main/scala/replpp/ScriptRunner.scala
@@ -30,7 +30,7 @@ object ScriptRunner {
     os.write.over(predefPlusScriptFileTmp, scriptContent)
 
     new ScriptingDriver(
-      compilerArgs = compilerArgs(maybeAddDependencies(scriptCode, config)) :+ "-nowarn",
+      compilerArgs = compilerArgs(maybeAddDependencies(predefCode, scriptCode, config)) :+ "-nowarn",
       scriptFile = predefPlusScriptFileTmp.toIO,
       scriptArgs = scriptArgs.toArray
     ).compileAndRun()
@@ -42,10 +42,15 @@ object ScriptRunner {
     os.remove(predefPlusScriptFileTmp)
   }
 
-  private def maybeAddDependencies(scriptCode: String, config: Config): Config = {
+  private def maybeAddDependencies(predefCode: String, scriptCode: String, config: Config): Config = {
     val usingClausePrefix = "//> using lib "
     val dependenciesFromUsingClauses =
-      scriptCode.lines()
+      s"""
+         |$predefCode
+         |$scriptCode
+         |"""
+        .stripMargin
+        .lines()
         .map(_.trim)
         .filter(_.startsWith(usingClausePrefix))
         .map(_.drop(usingClausePrefix.length).trim)

--- a/src/main/scala/replpp/ScriptRunner.scala
+++ b/src/main/scala/replpp/ScriptRunner.scala
@@ -43,7 +43,7 @@ object ScriptRunner {
   }
 
   private def maybeAddDependencies(scriptCode: String, config: Config): Config = {
-    val usingClausePrefix = "//> using "
+    val usingClausePrefix = "//> using lib"
     val dependenciesFromUsingClauses =
       scriptCode.lines()
         .map(_.trim)
@@ -54,6 +54,7 @@ object ScriptRunner {
 
     config.copy(dependencies = config.dependencies ++ dependenciesFromUsingClauses)
   }
+
   private def wrapForMainargs(predefCode: String, scriptCode: String): String = {
     val mainImpl =
       if (scriptCode.contains("@main")) {

--- a/src/main/scala/replpp/ScriptRunner.scala
+++ b/src/main/scala/replpp/ScriptRunner.scala
@@ -43,12 +43,12 @@ object ScriptRunner {
   }
 
   private def maybeAddDependencies(scriptCode: String, config: Config): Config = {
-    val usingClausePrefix = "//> using lib"
+    val usingClausePrefix = "//> using lib "
     val dependenciesFromUsingClauses =
       scriptCode.lines()
         .map(_.trim)
         .filter(_.startsWith(usingClausePrefix))
-        .map(_.drop(usingClausePrefix.length))
+        .map(_.drop(usingClausePrefix.length).trim)
         .collect(Collectors.toList)
         .asScala
 

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -6,97 +6,107 @@ import org.scalatest.wordspec.AnyWordSpec
 class ScriptRunnerTest extends AnyWordSpec with Matchers {
 
   "execute simple single-statement script" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    exec(s"""os.write.over(os.Path("$testOutputPath"), "iwashere-simple")""")
-    os.read(testOutputFile) shouldBe "iwashere-simple"
+    execTest { testOutputPath =>
+      TestSetup(s"""os.write.over(os.Path("$testOutputPath"), "iwashere-simple")""")
+    } shouldBe "iwashere-simple"
   }
 
   "main entry point" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    exec(
-      s"""@main def foo() = {
-         |  os.write.over(os.Path("$testOutputPath"), "iwashere-@main")
-         |}""".stripMargin)
-
-    os.read(testOutputFile) shouldBe "iwashere-@main"
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""@main def foo() = {
+           |  os.write.over(os.Path("$testOutputPath"), "iwashere-@main")
+           |}""".stripMargin
+      )
+    } shouldBe "iwashere-@main"
   }
 
   "multiple main entry points" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    exec(
-      s"""@main def foo() = {
-         |  os.write.append(os.Path("$testOutputPath"), "iwashere-@main-foo")
-         |}
-         |
-         |@main def bar() = {
-         |  os.write.append(os.Path("$testOutputPath"), "iwashere-@main-bar")
-         |}""".stripMargin,
-      adaptConfig = _.copy(command = Some("bar"))
-    )
-
-    os.read(testOutputFile) shouldBe "iwashere-@main-bar"
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""@main def foo() = {
+           |  os.write.append(os.Path("$testOutputPath"), "iwashere-@main-foo")
+           |}
+           |
+           |@main def bar() = {
+           |  os.write.append(os.Path("$testOutputPath"), "iwashere-@main-bar")
+           |}""".stripMargin,
+        adaptConfig = _.copy(command = Some("bar"))
+      )
+    } shouldBe "iwashere-@main-bar"
   }
 
   "parameters" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    exec(
-      s"""@main def foo(value: String) = {
-         |  os.write.over(os.Path("$testOutputPath"), value)
-         |}""".stripMargin,
-      adaptConfig = _.copy(params = Map("value" -> "iwashere-parameter"))
-    )
-
-    os.read(testOutputFile) shouldBe "iwashere-parameter"
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""@main def foo(value: String) = {
+           |  os.write.over(os.Path("$testOutputPath"), value)
+           |}""".stripMargin,
+        adaptConfig = _.copy(params = Map("value" -> "iwashere-parameter"))
+      )
+    } shouldBe "iwashere-parameter"
   }
 
   "--predefCode" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    exec(
-      s"""@main def foo() = {
-         |  os.write.over(os.Path("$testOutputPath"), bar)
-         |}""".stripMargin,
-      adaptConfig = _.copy(predefCode = Some("val bar = \"iwashere-predefCode\""))
-    )
-
-    os.read(testOutputFile) shouldBe "iwashere-predefCode"
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""@main def foo() = {
+           |  os.write.over(os.Path("$testOutputPath"), bar)
+           |}""".stripMargin,
+        adaptConfig = _.copy(predefCode = Some("val bar = \"iwashere-predefCode\""))
+      )
+    } shouldBe "iwashere-predefCode"
   }
 
   "--predefFiles" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    val predefFile = os.temp()
-    os.write.over(predefFile, "val bar = \"iwashere-predefFile\"")
-    exec(
-      s"""@main def foo() = {
-         |  os.write.over(os.Path("$testOutputPath"), bar)
-         |}""".stripMargin,
+    execTest { testOutputPath =>
+      val predefFile = os.temp()
+      os.write.over(predefFile, "val bar = \"iwashere-predefFile\"")
+      TestSetup(
+        s"""@main def foo() = {
+           |  os.write.over(os.Path("$testOutputPath"), bar)
+           |}""".stripMargin,
         adaptConfig = _.copy(predefFiles = List(predefFile))
-    )
-
-    os.read(testOutputFile) shouldBe "iwashere-predefFile"
+      )
+    } shouldBe "iwashere-predefFile"
   }
 
   "additional dependencies via --dependency" in {
-    val (testOutputFile, testOutputPath) = newTempFileWithPath
-    exec(
-      s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
-         |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency0:" + compareResult)
-         |""".stripMargin,
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency0:" + compareResult)
+           |""".stripMargin,
         adaptConfig = _.copy(dependencies = Seq("com.michaelpollmeier:versionsort:1.0.7"))
-    )
-
-    os.read(testOutputFile) shouldBe "iwashere-dependency0:1"
+      )
+    } shouldBe "iwashere-dependency0:1"
   }
 
-  private def exec(scriptSrc: String, adaptConfig: Config => Config = identity): Unit = {
+  "additional dependencies via --dependency 2" in {
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency0:" + compareResult)
+           |""".stripMargin,
+        adaptConfig = _.copy(dependencies = Seq("com.michaelpollmeier:versionsort:1.0.7"))
+      )
+    } shouldBe "iwashere-dependency0:1"
+  }
+
+  type TestOutputPath = String
+  type TestOutput = String
+  case class TestSetup(scriptSrc: String, adaptConfig: Config => Config = identity)
+  private def execTest(setupTest: TestOutputPath => TestSetup): TestOutput = {
+    val testOutputFile = os.temp()
+    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+
+    val TestSetup(scriptSrc, adaptConfig) = setupTest(testOutputPath)
     val scriptFile = os.temp()
     os.write.over(scriptFile, scriptSrc)
     val config = adaptConfig(Config(scriptFile = Some(scriptFile)))
     ScriptRunner.exec(config)
-  }
 
-  private def newTempFileWithPath: (os.Path, String) = {
-    val tmpFile = os.temp()
-    (tmpFile, tmpFile.toNIO.toAbsolutePath.toString)
+    os.read(testOutputFile)
   }
 
 }

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -21,7 +21,7 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     os.read(testOutputFile) shouldBe "iwashere-@main"
   }
 
-  "multiple main entry point" in {
+  "multiple main entry points" in {
     val (testOutputFile, testOutputPath) = newTempFileWithPath
     exec(
       s"""@main def foo() = {
@@ -35,6 +35,18 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     )
 
     os.read(testOutputFile) shouldBe "iwashere-@main-bar"
+  }
+
+  "parameters" in {
+    val (testOutputFile, testOutputPath) = newTempFileWithPath
+    exec(
+      s"""@main def foo(value: String) = {
+         |  os.write.over(os.Path("$testOutputPath"), value)
+         |}""".stripMargin,
+      adaptConfig = _.copy(params = Map("value" -> "iwashere-parameter"))
+    )
+
+    os.read(testOutputFile) shouldBe "iwashere-parameter"
   }
 
   "--predefCode" in {

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -23,14 +23,24 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     os.read(testOutputFile) shouldBe "iwashere-@main"
   }
 
-//  "--predefCode" in {
-//    ???
-//  }
+  "--predefCode" in {
+    val testOutputFile = os.temp()
+    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+    exec(
+      s"""@main def foo() = {
+         |  os.write.over(os.Path("$testOutputPath"), bar)
+         |}""".stripMargin,
+        adaptConfig = _.copy(predefCode = Some("val bar = \"iwashere-predefCode\""))
+    )
 
-  private def exec(scriptSrc: String): Unit = {
+    os.read(testOutputFile) shouldBe "iwashere-predefCode"
+  }
+
+  private def exec(scriptSrc: String, adaptConfig: Config => Config = identity): Unit = {
     val scriptFile = os.temp()
     os.write.over(scriptFile, scriptSrc)
-    ScriptRunner.exec(Config(scriptFile = Some(scriptFile)))
+    val config = adaptConfig(Config(scriptFile = Some(scriptFile)))
+    ScriptRunner.exec(config)
   }
 
 

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -1,0 +1,28 @@
+package replpp
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ScriptRunnerTest extends AnyWordSpec with Matchers {
+
+  "execute simple single-statement script" in {
+    val scriptFile = os.temp()
+    val testOutputFile = os.temp()
+    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+    os.write.over(
+      scriptFile,
+      s"""os.write.over(os.Path("$testOutputPath"), "iwashere")"""
+    )
+
+    ScriptRunner.exec(Config(scriptFile = Some(scriptFile)))
+    os.read(testOutputFile) shouldBe "iwashere"
+  }
+
+//  "@main entry point" in {
+//  }
+
+//  "--predefCode" in {
+//    ???
+//  }
+
+}

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -6,15 +6,11 @@ import org.scalatest.wordspec.AnyWordSpec
 class ScriptRunnerTest extends AnyWordSpec with Matchers {
 
   "execute simple single-statement script" in {
-    val scriptFile = os.temp()
     val testOutputFile = os.temp()
     val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
-    os.write.over(
-      scriptFile,
-      s"""os.write.over(os.Path("$testOutputPath"), "iwashere")"""
-    )
 
-    ScriptRunner.exec(Config(scriptFile = Some(scriptFile)))
+    exec(s"""os.write.over(os.Path("$testOutputPath"), "iwashere")""")
+
     os.read(testOutputFile) shouldBe "iwashere"
   }
 
@@ -24,5 +20,12 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
 //  "--predefCode" in {
 //    ???
 //  }
+
+  private def exec(scriptSrc: String): Unit = {
+    val scriptFile = os.temp()
+    os.write.over(scriptFile, scriptSrc)
+    ScriptRunner.exec(Config(scriptFile = Some(scriptFile)))
+  }
+
 
 }

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -50,9 +50,7 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
   "--predefCode" in {
     execTest { testOutputPath =>
       TestSetup(
-        s"""@main def foo() = {
-           |  os.write.over(os.Path("$testOutputPath"), bar)
-           |}""".stripMargin,
+        s"""os.write.over(os.Path("$testOutputPath"), bar)""".stripMargin,
         adaptConfig = _.copy(predefCode = Some("val bar = \"iwashere-predefCode\""))
       )
     } shouldBe "iwashere-predefCode"
@@ -63,23 +61,10 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
       val predefFile = os.temp()
       os.write.over(predefFile, "val bar = \"iwashere-predefFile\"")
       TestSetup(
-        s"""@main def foo() = {
-           |  os.write.over(os.Path("$testOutputPath"), bar)
-           |}""".stripMargin,
+        s"""os.write.over(os.Path("$testOutputPath"), bar)""".stripMargin,
         adaptConfig = _.copy(predefFiles = List(predefFile))
       )
     } shouldBe "iwashere-predefFile"
-  }
-
-  "additional dependencies via --dependency" in {
-    execTest { testOutputPath =>
-      TestSetup(
-        s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
-           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency0:" + compareResult)
-           |""".stripMargin,
-        adaptConfig = _.copy(dependencies = Seq("com.michaelpollmeier:versionsort:1.0.7"))
-      )
-    } shouldBe "iwashere-dependency0:1"
   }
 
   "additional dependencies via --dependency 2" in {

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -90,7 +90,7 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     } shouldBe "iwashere-dependency-using-script:1"
   }
 
-  "additional dependencies via `//> using lib` in predefCode" in {
+  "additional dependencies via `//> using lib` in --predefCode" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""
@@ -100,6 +100,20 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
         adaptConfig = _.copy(predefCode = Some("//> using lib com.michaelpollmeier:versionsort:1.0.7"))
       )
     } shouldBe "iwashere-dependency-using-predefCode:1"
+  }
+
+  "additional dependencies via `//> using lib` in --predefFiles" in {
+    execTest { testOutputPath =>
+      val predefFile = os.temp()
+      os.write.over(predefFile, "//> using lib com.michaelpollmeier:versionsort:1.0.7")
+      TestSetup(
+        s"""
+           |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency-using-predefFiles:" + compareResult)
+           |""".stripMargin,
+        adaptConfig = _.copy(predefFiles = List(predefFile))
+      )
+    } shouldBe "iwashere-dependency-using-predefFiles:1"
   }
 
   type TestOutputPath = String

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -8,14 +8,20 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
   "execute simple single-statement script" in {
     val testOutputFile = os.temp()
     val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
-
-    exec(s"""os.write.over(os.Path("$testOutputPath"), "iwashere")""")
-
-    os.read(testOutputFile) shouldBe "iwashere"
+    exec(s"""os.write.over(os.Path("$testOutputPath"), "iwashere-simple")""")
+    os.read(testOutputFile) shouldBe "iwashere-simple"
   }
 
-//  "@main entry point" in {
-//  }
+  "main entry point" in {
+    val testOutputFile = os.temp()
+    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+    exec(
+      s"""@main def foo() = {
+         |  os.write.over(os.Path("$testOutputPath"), "iwashere-@main")
+         |}""".stripMargin)
+
+    os.read(testOutputFile) shouldBe "iwashere-@main"
+  }
 
 //  "--predefCode" in {
 //    ???

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -6,15 +6,13 @@ import org.scalatest.wordspec.AnyWordSpec
 class ScriptRunnerTest extends AnyWordSpec with Matchers {
 
   "execute simple single-statement script" in {
-    val testOutputFile = os.temp()
-    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+    val (testOutputFile, testOutputPath) = newTempFileWithPath
     exec(s"""os.write.over(os.Path("$testOutputPath"), "iwashere-simple")""")
     os.read(testOutputFile) shouldBe "iwashere-simple"
   }
 
   "main entry point" in {
-    val testOutputFile = os.temp()
-    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+    val (testOutputFile, testOutputPath) = newTempFileWithPath
     exec(
       s"""@main def foo() = {
          |  os.write.over(os.Path("$testOutputPath"), "iwashere-@main")
@@ -24,8 +22,7 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
   }
 
   "--predefCode" in {
-    val testOutputFile = os.temp()
-    val testOutputPath = testOutputFile.toNIO.toAbsolutePath.toString
+    val (testOutputFile, testOutputPath) = newTempFileWithPath
     exec(
       s"""@main def foo() = {
          |  os.write.over(os.Path("$testOutputPath"), bar)
@@ -43,5 +40,9 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     ScriptRunner.exec(config)
   }
 
+  private def newTempFileWithPath: (os.Path, String) = {
+    val tmpFile = os.temp()
+    (tmpFile, tmpFile.toNIO.toAbsolutePath.toString)
+  }
 
 }

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -71,11 +71,11 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     execTest { testOutputPath =>
       TestSetup(
         s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
-           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency0:" + compareResult)
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency-param:" + compareResult)
            |""".stripMargin,
         adaptConfig = _.copy(dependencies = Seq("com.michaelpollmeier:versionsort:1.0.7"))
       )
-    } shouldBe "iwashere-dependency0:1"
+    } shouldBe "iwashere-dependency-param:1"
   }
 
   "additional dependencies via `//> using lib` in script" in {
@@ -84,10 +84,22 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
         s"""
            |//> using lib com.michaelpollmeier:versionsort:1.0.7
            |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
-           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency1:" + compareResult)
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency-using-script:" + compareResult)
            |""".stripMargin
       )
-    } shouldBe "iwashere-dependency1:1"
+    } shouldBe "iwashere-dependency-using-script:1"
+  }
+
+  "additional dependencies via `//> using lib` in predefCode" in {
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""
+           |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency-using-predefCode:" + compareResult)
+           |""".stripMargin,
+        adaptConfig = _.copy(predefCode = Some("//> using lib com.michaelpollmeier:versionsort:1.0.7"))
+      )
+    } shouldBe "iwashere-dependency-using-predefCode:1"
   }
 
   type TestOutputPath = String

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -67,7 +67,7 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     } shouldBe "iwashere-predefFile"
   }
 
-  "additional dependencies via --dependency 2" in {
+  "additional dependencies via --dependency" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
@@ -76,6 +76,18 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
         adaptConfig = _.copy(dependencies = Seq("com.michaelpollmeier:versionsort:1.0.7"))
       )
     } shouldBe "iwashere-dependency0:1"
+  }
+
+  "additional dependencies via `//> using lib` in script" in {
+    execTest { testOutputPath =>
+      TestSetup(
+        s"""
+           |//> using lib com.michaelpollmeier:versionsort:1.0.7
+           |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
+           |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency1:" + compareResult)
+           |""".stripMargin
+      )
+    } shouldBe "iwashere-dependency1:1"
   }
 
   type TestOutputPath = String

--- a/src/test/scala/replpp/ScriptRunnerTest.scala
+++ b/src/test/scala/replpp/ScriptRunnerTest.scala
@@ -75,6 +75,18 @@ class ScriptRunnerTest extends AnyWordSpec with Matchers {
     os.read(testOutputFile) shouldBe "iwashere-predefFile"
   }
 
+  "additional dependencies via --dependency" in {
+    val (testOutputFile, testOutputPath) = newTempFileWithPath
+    exec(
+      s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
+         |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency0:" + compareResult)
+         |""".stripMargin,
+        adaptConfig = _.copy(dependencies = Seq("com.michaelpollmeier:versionsort:1.0.7"))
+    )
+
+    os.read(testOutputFile) shouldBe "iwashere-dependency0:1"
+  }
+
   private def exec(scriptSrc: String, adaptConfig: Config => Config = identity): Unit = {
     val scriptFile = os.temp()
     os.write.over(scriptFile, scriptSrc)


### PR DESCRIPTION
... to match the [scala-cli using directive syntax](https://scala-cli.virtuslab.org/docs/guides/using-directives/)
and make space for `//> using file` to import additional scripts (coming shortly). 

This also adds a test suite for ScriptRunner and updates the readme.