### PR TITLE
upgrade dependencies (other than os-lib)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,10 @@ lazy val core = project.in(file("core")).settings(
   libraryDependencies ++= Seq(
     "org.scala-lang"   %% "scala3-compiler" % scalaVersion.value,
     "com.lihaoyi"      %% "mainargs"  % "0.3.0",
-    "com.lihaoyi"      %% "os-lib"    % "0.8.1",
-    "com.lihaoyi"      %% "pprint"    % "0.7.3",
+    "com.lihaoyi"      %% "os-lib"    % "0.9.0",
+    "com.lihaoyi"      %% "pprint"    % "0.8.1",
     "com.github.scopt" %% "scopt"     % "4.1.0",
-    ("io.get-coursier" %% "coursier"  % "2.0.13").cross(CrossVersion.for3Use2_13)
+    ("io.get-coursier" %% "coursier"  % "2.0.16").cross(CrossVersion.for3Use2_13)
       .exclude("org.scala-lang.modules", "scala-xml_2.13")
       .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
     "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
@@ -29,8 +29,8 @@ lazy val server = project.in(file("server"))
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       "com.lihaoyi"   %% "cask"         % "0.8.3",
-      "org.slf4j"      % "slf4j-simple" % "1.7.36" % Optional,
-      "com.lihaoyi"   %% "requests"     % "0.7.1" % Test,
+      "org.slf4j"      % "slf4j-simple" % "2.0.6" % Optional,
+      "com.lihaoyi"   %% "requests"     % "0.8.0" % Test,
       "org.scalatest" %% "scalatest"    % ScalaTestVersion % "it",
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "root"
 publish/skip := true
 
 ThisBuild / organization := "com.michaelpollmeier"
-ThisBuild / scalaVersion := "3.3.0-RC2"
+ThisBuild / scalaVersion := "3.3.0-RC3"
 
 lazy val ScalaTestVersion = "3.2.15"
 
@@ -11,7 +11,7 @@ lazy val core = project.in(file("core")).settings(
   libraryDependencies ++= Seq(
     "org.scala-lang"   %% "scala3-compiler" % scalaVersion.value,
     "com.lihaoyi"      %% "mainargs"  % "0.3.0",
-    "com.lihaoyi"      %% "os-lib"    % "0.9.0",
+    "com.lihaoyi"      %% "os-lib"    % "0.8.1",
     "com.lihaoyi"      %% "pprint"    % "0.8.1",
     "com.github.scopt" %% "scopt"     % "4.1.0",
     ("io.get-coursier" %% "coursier"  % "2.0.16").cross(CrossVersion.for3Use2_13)


### PR DESCRIPTION
os-lib triggers a cask-util version conflict...

```
[error] (server / update) found version conflict(s) in library dependencies; 
some are suspected to be binary incompatible:
[error]
[error] * com.lihaoyi:geny_3:1.0.0 (early-semver) is selected over {0.6.10, 0.7.1}
[error]     +- com.lihaoyi:os-lib_3:0.9.0 (depends on 1.0.0)
[error]     +- com.lihaoyi:upickle-core_3:1.6.0 (depends on 0.7.1)
[error]     +- com.lihaoyi:cask-util_3:0.8.3 (depends on 0.6.10)
```