### PR TITLE
various refactorings

### DIFF
--- a/all/src/main/scala/replpp/all/Main.scala
+++ b/all/src/main/scala/replpp/all/Main.scala
@@ -1,16 +1,8 @@
 package replpp.all
 
-import replpp.{Config, InteractiveShell}
 import replpp.scripting.ScriptRunner
 import replpp.server.ReplServer
-
-import java.io.{InputStream, PrintStream, File as JFile}
-import java.net.URLClassLoader
-import java.nio.file.{Files, Path, Paths}
-import java.util
-import java.util.stream
-import java.util.stream.Collectors
-import scala.jdk.CollectionConverters.*
+import replpp.{Config, InteractiveShell}
 
 object Main {
   def main(args: Array[String]): Unit = {

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -13,6 +13,7 @@ import dotty.tools.repl.*
 import org.jline.reader.*
 
 import java.io.PrintStream
+import java.lang.System.lineSeparator
 import java.net.URL
 import java.nio.file.{Files, Path}
 import javax.naming.InitialContext
@@ -28,8 +29,6 @@ class ReplDriver(args: Array[String],
                  prompt: String,
                  maxPrintElements: Int,
                  classLoader: Option[ClassLoader] = None) extends dotty.tools.repl.ReplDriver(args, out, classLoader) {
-
-  lazy val lineSeparator = System.getProperty("line.separator")
 
   /** Run REPL with `state` until `:quit` command found
     * Main difference to the 'original': different greeting, trap Ctrl-c

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -15,7 +15,7 @@ import org.jline.reader.*
 import java.io.PrintStream
 import java.lang.System.lineSeparator
 import java.net.URL
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import javax.naming.InitialContext
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -94,7 +94,7 @@ class ReplDriver(args: Array[String],
       // now read and interpret the given file
       val pathStr = line.trim.drop(UsingDirectives.FileDirective.length)
       val path = resolveFile(currentFile, pathStr)
-      val linesFromFile = Files.readAllLines(path).asScala
+      val linesFromFile = util.linesFromFile(path)
       println(s"> importing $path (${linesFromFile.size} lines)")
       resultingState = interpretInput(linesFromFile, resultingState, path)
     }

--- a/core/src/main/scala/replpp/UsingDirectives.scala
+++ b/core/src/main/scala/replpp/UsingDirectives.scala
@@ -41,11 +41,11 @@ object UsingDirectives {
     results.result().distinct
   }
 
-  def findDeclaredDependencies(source: String): Seq[String] =
-    scanFor(LibDirective, source.linesIterator)
+  def findDeclaredDependencies(lines: IterableOnce[String]): Seq[String] =
+    scanFor(LibDirective, lines)
 
-  def findResolvers(source: String): Seq[String] =
-    scanFor(ResolverDirective, source.linesIterator)
+  def findResolvers(lines: IterableOnce[String]): Seq[String] =
+    scanFor(ResolverDirective, lines)
 
   private def scanFor(directive: String, lines: IterableOnce[String]): Seq[String] = {
     lines

--- a/core/src/main/scala/replpp/UsingDirectives.scala
+++ b/core/src/main/scala/replpp/UsingDirectives.scala
@@ -2,7 +2,6 @@ package replpp
 
 import java.nio.file.{Files, Path}
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 object UsingDirectives {
   private val Prefix    = "//> using"
@@ -15,7 +14,7 @@ object UsingDirectives {
       if (Files.isDirectory(path)) path
       else path.getParent
 
-    val importedFiles = findImportedFiles(Files.lines(path).iterator.asScala, rootDir)
+    val importedFiles = findImportedFiles(util.linesFromFile(path), rootDir)
     val recursivelyImportedFiles = importedFiles.filterNot(visited.contains).flatMap { file =>
       findImportedFilesRecursively(file, visited + file)
     }

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -36,11 +36,11 @@ package object replpp {
     compilerArgs.result()
   }
 
-  def classpath(config: Config): String = {
+  def classpath(config: Config, quiet: Boolean = false): String = {
     val fromJavaClassPathProperty = System.getProperty("java.class.path")
     val fromDependencies = dependencyArtifacts(config)
 
-    if (fromDependencies.nonEmpty) {
+    if (fromDependencies.nonEmpty && !quiet) {
       println(s"resolved dependencies - adding ${fromDependencies.size} artifact(s) to classpath - to list them, enable verbose mode")
       if (verboseEnabled(config)) fromDependencies.foreach(println)
     }

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -1,10 +1,13 @@
+import replpp.util.linesFromFile
+
 import java.io.File
 import java.lang.System.lineSeparator
 import java.net.URL
-import replpp.util.linesFromFile
 import java.nio.file.{Files, Path, Paths}
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.io.Source
+import scala.util.Using
 
 package object replpp {
   /* ":" on unix */
@@ -54,15 +57,13 @@ package object replpp {
   }
 
   private def dependencyArtifacts(config: Config): Seq[File] = {
-    val predefCode = allPredefCode(config)
-    val scriptCode = config.scriptFile.map(Files.readString).getOrElse("")
-    val allCode = 
-      s"""$predefCode
-         |$scriptCode""".stripMargin
-      
-    val resolvers = config.resolvers ++ UsingDirectives.findResolvers(allCode)
-    val allDependencies = config.dependencies ++
-      UsingDirectives.findDeclaredDependencies(allCode)
+    val scriptLines = config.scriptFile.map { path =>
+       Using.resource(Source.fromFile(path.toFile))(_.getLines.toSeq)
+    }.getOrElse(Seq.empty)
+    val allLines = allPredefLines(config) ++ scriptLines
+
+    val resolvers = config.resolvers ++ UsingDirectives.findResolvers(allLines)
+    val allDependencies = config.dependencies ++ UsingDirectives.findDeclaredDependencies(allLines)
     Dependencies.resolve(allDependencies, resolvers).get
   }
   
@@ -75,7 +76,10 @@ package object replpp {
     }
   }
 
-  def allPredefCode(config: Config): String = {
+  def allPredefCode(config: Config): String =
+    allPredefLines(config).mkString(lineSeparator)
+
+  def allPredefLines(config: Config): Seq[String] = {
     val resultLines = Seq.newBuilder[String]
     val visited = mutable.Set.empty[Path]
 
@@ -122,9 +126,7 @@ package object replpp {
       }
     }
 
-    resultLines.result()
-      .filterNot(_.trim.startsWith(UsingDirectives.FileDirective))
-      .mkString(lineSeparator)
+    resultLines.result().filterNot(_.trim.startsWith(UsingDirectives.FileDirective))
   }
 
   private def lines(str: String): Seq[String] =

--- a/core/src/main/scala/replpp/scripting/ScriptRunner.scala
+++ b/core/src/main/scala/replpp/scripting/ScriptRunner.scala
@@ -15,7 +15,7 @@ object ScriptRunner {
   def exec(config: Config): Try[Unit] = {
     val args = Seq(
       "-classpath",
-      replpp.classpath(config),
+      replpp.classpath(config, quiet = true),
       "replpp.scripting.NonForkingScriptRunner",
     ) ++ config.asJavaArgs
     if (replpp.verboseEnabled(config)) println(s"executing `java ${args.mkString(" ")}`")

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -2,8 +2,9 @@ package replpp
 
 import java.nio.file.{Files, Path}
 import scala.collection.immutable.Seq
+import scala.io.Source
 import scala.jdk.CollectionConverters.*
-import scala.util.Try
+import scala.util.{Try, Using}
 
 package object util {
   
@@ -18,10 +19,7 @@ package object util {
   }
 
   def linesFromFile(path: Path): Seq[String] =
-    linesStreamFromFile(path).iterator.toSeq
-
-  def linesStreamFromFile(path: Path): IterableOnce[String] =
-    Files.lines(path).iterator().asScala
+    Using.resource(Source.fromFile(path.toFile))(_.getLines.toSeq)
 
   def deleteRecursively(path: Path): Unit = {
     if (Files.isDirectory(path))

--- a/core/src/test/scala/replpp/UsingDirectivesTests.scala
+++ b/core/src/test/scala/replpp/UsingDirectivesTests.scala
@@ -58,7 +58,7 @@ class UsingDirectivesTests extends AnyWordSpec with Matchers {
         |// //> using lib commented:out:1.3
         |""".stripMargin
 
-    val results = UsingDirectives.findDeclaredDependencies(source)
+    val results = UsingDirectives.findDeclaredDependencies(source.linesIterator)
     results should contain("com.example:some-dependency:1.1")
     results should contain("com.example::scala-dependency:1.2")
     results should not contain "commented:out:1.3"
@@ -72,7 +72,7 @@ class UsingDirectivesTests extends AnyWordSpec with Matchers {
         |// //> using resolver https://commented.out/repo
         |""".stripMargin
 
-    val results = UsingDirectives.findResolvers(source)
+    val results = UsingDirectives.findResolvers(source.linesIterator)
     results should contain("https://repository.apache.org/content/groups/public")
     results should contain("https://shiftleft.jfrog.io/shiftleft/libs-release-local")
     results should not contain "https://commented.out/repo"


### PR DESCRIPTION
* use stdlib constant for lineSeparator
* optional `quiet` mode when calculating classpath
* use `lines: Seq[String]` instead of `code: String` to avoid extra conversions
* reading files: consolidate, use automatic resource management