### PR TITLE
report status about artifact fetching

### DIFF
--- a/core/src/main/scala/replpp/Dependencies.scala
+++ b/core/src/main/scala/replpp/Dependencies.scala
@@ -2,6 +2,7 @@ package replpp
 
 import coursier.Dependency
 import coursier.cache.FileCache
+import coursier.cache.loggers.RefreshLogger
 import coursier.core.Repository
 import coursier.parse.{DependencyParser, RepositoryParser}
 
@@ -16,8 +17,11 @@ object Dependencies {
       repositories <- parseRepositories(additionalRepositories)
       dependencies <- parseDependencies(coordinates)
     } yield {
+      // the default cache throws away the credentials... see PlatformCacheCompanion.scala
+      val cache = FileCache().withLogger(RefreshLogger.create())
+
       coursier.Fetch()
-        .withCache(FileCache()) // the default cache throws away the credentials... see PlatformCacheCompanion.scala
+        .withCache(cache)
         .addRepositories(repositories: _*)
         .addDependencies(dependencies: _*)
         .run()


### PR DESCRIPTION
updated dynamically when running, e.g. like this:
```
https://shiftleft.jfrog.io/shiftleft/libs-release-local/io/shiftleft/common_3/0.3.109/common_3-0.3.109.pom
  100.0% [##########] 2.7 KiB (4.3 KiB / s)
https://shiftleft.jfrog.io/shiftleft/libs-release-local/io/shiftleft/common_3/0.3.109/common_3-0.3.109.jar
  100.0% [##########] 135.3 KiB (123.3 KiB / s)
```