### PR TITLE
correct copy error: `using lib` -> `using dep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ val res0: Int = 1
 ```
 To add multiple dependencies, you can specify this parameter multiple times.
 
-Alternatively, use the `//> using lib` directive in predef code or predef files:
+Alternatively, use the `//> using dep` directive in predef code or predef files:
 ```
-echo '//> using lib com.michaelpollmeier:versionsort:1.0.7' > predef.sc
+echo '//> using dep com.michaelpollmeier:versionsort:1.0.7' > predef.sc
 
 ./scala-repl-pp --predef predef.sc
 
@@ -181,11 +181,11 @@ println(foo)
 ```
 
 ### Dependencies
-Dependencies can be added via `//> using lib` syntax (like in scala-cli).
+Dependencies can be added via `//> using dep` syntax (like in scala-cli).
 
 test-dependencies.sc:
 ```scala
-//> using lib com.michaelpollmeier:versionsort:1.0.7
+//> using dep com.michaelpollmeier:versionsort:1.0.7
 
 val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
 assert(compareResult == 1,
@@ -243,7 +243,7 @@ Or via `//> using resolver` directive as part of your script or predef code:
 script-with-resolver.sc
 ```scala
 //> using resolver https://repo.gradle.org/gradle/libs-releases
-//> using lib org.gradle:gradle-tooling-api:7.6.1
+//> using dep org.gradle:gradle-tooling-api:7.6.1
 println(org.gradle.tooling.GradleConnector.newConnector())
 ```
 ```scala

--- a/core/src/main/scala/replpp/UsingDirectives.scala
+++ b/core/src/main/scala/replpp/UsingDirectives.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 
 object UsingDirectives {
   private val Prefix    = "//> using"
-  val LibDirective      = s"$Prefix lib "
+  val LibDirective      = s"$Prefix dep "
   val FileDirective     = s"$Prefix file "
   val ResolverDirective = s"$Prefix resolver"
 

--- a/core/src/test/scala/replpp/UsingDirectivesTests.scala
+++ b/core/src/test/scala/replpp/UsingDirectivesTests.scala
@@ -53,9 +53,9 @@ class UsingDirectivesTests extends AnyWordSpec with Matchers {
   "find declared dependencies" in {
     val source =
       """
-        |//> using lib com.example:some-dependency:1.1
-        |//> using lib com.example::scala-dependency:1.2
-        |// //> using lib commented:out:1.3
+        |//> using dep com.example:some-dependency:1.1
+        |//> using dep com.example::scala-dependency:1.2
+        |// //> using dep commented:out:1.3
         |""".stripMargin
 
     val results = UsingDirectives.findDeclaredDependencies(source.linesIterator)

--- a/core/src/test/scala/replpp/scripting/ScriptRunnerTests.scala
+++ b/core/src/test/scala/replpp/scripting/ScriptRunnerTests.scala
@@ -51,7 +51,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-parameter"
   }
 
-  "--predefCode" in {
+  "predefCode" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""os.write.over(os.Path("$testOutputPath"), bar)""".stripMargin,
@@ -60,7 +60,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-predefCode"
   }
 
-  "--predefCode imports" in {
+  "predefCode imports" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""os.write.over(os.Path("$testOutputPath"), "iwashere-predefCode-import-" + MaxValue)""".stripMargin,
@@ -69,7 +69,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-predefCode-import-127"
   }
 
-  "--predefCode imports in additionalScripts" in {
+  "predefCode imports in additionalScripts" in {
     execTest { testOutputPath =>
       val additionalScript = os.temp()
       os.write.over(additionalScript, "def foo = MaxValue")
@@ -82,7 +82,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-predefCode-using-file-import:127"
   }
 
-  "--predefFiles" in {
+  "predefFiles" in {
     execTest { testOutputPath =>
       val predefFile = os.temp("val bar = \"iwashere-predefFile\"").toNIO
       TestSetup(
@@ -92,7 +92,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-predefFile"
   }
 
-  "--predefFiles imports are available" in {
+  "predefFiles imports are available" in {
     execTest { testOutputPath =>
       val predefFile = os.temp("import Byte.MaxValue").toNIO
       TestSetup(
@@ -102,7 +102,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-predefFile-127"
   }
 
-  "additional dependencies via --dependency" in {
+  "additional dependencies" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
@@ -113,11 +113,11 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-dependency-param:1"
   }
 
-  "additional dependencies via `//> using lib` in script" in {
+  "additional dependencies via `//> using dep` in script" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""
-           |//> using lib com.michaelpollmeier:versionsort:1.0.7
+           |//> using dep com.michaelpollmeier:versionsort:1.0.7
            |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
            |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency-using-script:" + compareResult)
            |""".stripMargin
@@ -125,21 +125,21 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-dependency-using-script:1"
   }
 
-  "additional dependencies via `//> using lib` in --predefCode" in {
+  "additional dependencies via `//> using dep` in predefCode" in {
     execTest { testOutputPath =>
       TestSetup(
         s"""
            |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
            |os.write.over(os.Path("$testOutputPath"), "iwashere-dependency-using-predefCode:" + compareResult)
            |""".stripMargin,
-        adaptConfig = _.copy(predefCode = Some("//> using lib com.michaelpollmeier:versionsort:1.0.7"))
+        adaptConfig = _.copy(predefCode = Some("//> using dep com.michaelpollmeier:versionsort:1.0.7"))
       )
     }.get shouldBe "iwashere-dependency-using-predefCode:1"
   }
 
-  "additional dependencies via `//> using lib` in --predefFiles" in {
+  "additional dependencies via `//> using dep` in predefFiles" in {
     execTest { testOutputPath =>
-      val predefFile = os.temp("//> using lib com.michaelpollmeier:versionsort:1.0.7").toNIO
+      val predefFile = os.temp("//> using dep com.michaelpollmeier:versionsort:1.0.7").toNIO
       TestSetup(
         s"""
            |val compareResult = versionsort.VersionHelper.compare("1.0", "0.9")
@@ -162,7 +162,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-using-file-test1:99"
   }
 
-  "import additional files via `//> using file` via --predefCode" in {
+  "import additional files via `//> using file` via predefCode" in {
     execTest { testOutputPath =>
       val additionalScript = os.temp()
       os.write.over(additionalScript, "def foo = 99")
@@ -175,7 +175,7 @@ class ScriptRunnerTests extends AnyWordSpec with Matchers {
     }.get shouldBe "iwashere-using-file-test2:99"
   }
 
-  "import additional files via `//> using file` via --predefFiles" in {
+  "import additional files via `//> using file` via predefFiles" in {
     execTest { testOutputPath =>
       val additionalScript = os.temp("def foo = 99")
       val predefFile = os.temp(s"//> using file $additionalScript").toNIO


### PR DESCRIPTION
the idea always was to use the same syntax as scala-cli, I somehow
messed that up before... https://scala-cli.virtuslab.org/docs/guides/using-directives/