### PR TITLE
drop additionalHandler for pretty printing

### DIFF
--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -13,8 +13,7 @@ object PPrinter {
     new pprint.PPrinter(
       defaultHeight = 99999,
       colorLiteral = fansi.Attrs.Empty, // leave color highlighting to the repl
-      colorApplyPrefix = fansi.Attrs.Empty,
-      additionalHandlers = handleProduct(pprint.PPrinter.BlackWhite)) {
+      colorApplyPrefix = fansi.Attrs.Empty) {
 
       override def tokenize(x: Any,
                             width: Int = defaultWidth,
@@ -55,23 +54,5 @@ object PPrinter {
         "\u001b\\[[00]+;0?(\\d+);0?(\\d+);0?(\\d+)m",
         "\u001b[$1;$2;$3m"
       ) // `[00;38;05;70m` is encoded as `[38;5;70m` in fansi - 8bit color encoding
-
-  private def handleProduct(original: pprint.PPrinter): PartialFunction[Any, Tree] = {
-    case product: Product =>
-      Tree.Apply(
-        product.productPrefix,
-        Iterator.range(0, product.productArity).map { elementIdx =>
-          val elementValueTree = original.treeify(
-            product.productElement(elementIdx),
-            escapeUnicode = original.defaultEscapeUnicode,
-            showFieldNames = original.defaultShowFieldNames
-          )
-          product.productElementName(elementIdx) match {
-            case "" => elementValueTree
-            case name => Tree.Infix(Tree.Literal(name), "->", elementValueTree)
-          }
-        }
-      )
-  }
 
 }

--- a/core/src/test/scala/replpp/PPrinterTests.scala
+++ b/core/src/test/scala/replpp/PPrinterTests.scala
@@ -14,6 +14,29 @@ class PPrinterTests extends AnyWordSpec with Matchers {
   val FBold              = "\u001b[01mF\u001b[m"
   val X8bit              = "\u001b[00;38;05;70mX\u001b[m"
 
+  "print some common datastructures" in {
+    PPrinter(List(1,2)) shouldBe "List(1, 2)"
+    PPrinter((1,2,"three"))  shouldBe """(1, 2, "three")"""
+
+    case class A(i: Int, s: String)
+    PPrinter(A(42, "foo bar"))  shouldBe """A(i = 42, s = "foo bar")"""
+
+    PPrinter(new Product {
+      override def productPrefix = "Foo"
+      def productArity = 2
+      override def productElementName(n: Int) =
+        n match {
+          case 0 => "first"
+          case 1 => "second"
+        }
+      def productElement(n: Int) = n match {
+        case 0 => "one"
+        case 1 => "two"
+      }
+      def canEqual(that: Any): Boolean = ???
+    }) shouldBe """Foo(first = "one", second = "two")"""
+  }
+
   "fansi encoding fix" must {
     "handle different ansi encoding termination" in {
       // encoding ends with [39m for fansi instead of [m


### PR DESCRIPTION
This was necessary for handling custom products in the past, but
that's no longer required and we can just use the regular 'labelled
product' logic.

"Side effect" that was driving this change: fixes rendering for other Products like List:
before:
![image](https://user-images.githubusercontent.com/506752/234548120-e119d5e9-7cf2-4203-bee4-5540ae70540e.png)

with this PR:
![image](https://user-images.githubusercontent.com/506752/234548164-8160b774-8d45-4b6e-85a1-71f72693a291.png)
