### PR TITLE
streamline predef code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Scala REPL PlusPlus: a better Scala 3 REPL. With many features inspired by ammon
   * [Importing additional script files interactively](#importing-additional-script-files-interactively)
 - [Scripting](#scripting)
   * [Simple "Hello world" script](#simple-hello-world-script)
-  * [Predef code for script](#predef-code-for-script)
-  * [Predef code via environment variable](#predef-code-via-environment-variable)
-  * [Predef file(s)](#predef-files)
+  * [Predef file(s) used in script](#predef-files-used-in-script)
   * [Importing files / scripts](#importing-files--scripts)
   * [Dependencies](#dependencies)
   * [@main entrypoints](#main-entrypoints)
@@ -29,7 +27,7 @@ Scala REPL PlusPlus: a better Scala 3 REPL. With many features inspired by ammon
 - [Additional dependency resolvers and credentials](#additional-dependency-resolvers-and-credentials)
 - [Server mode](#server-mode)
 - [Embed into your own project](#embed-into-your-own-project)
-- [Predef code and scripts](#predef-code-and-scripts)
+- [Global predef file: `~/.scala-repl-pp.sc`](#global-predef-file-scala-repl-ppsc)
 - [Verbose mode](#verbose-mode)
 - [Limitations / Debugging](#limitations--debugging)
   * [Why are script line numbers incorrect?](#why-are-script-line-numbers-incorrect)
@@ -75,8 +73,10 @@ Generally speaking, `--help` is your friend!
 # customize prompt, greeting and exit code
 ./scala-repl-pp --prompt myprompt --greeting 'hey there!' --onExitCode 'println("see ya!")'
 
-# pass some predef code
-./scala-repl-pp --predefCode 'def foo = 42'
+# pass some predef code in file(s)
+echo 'def foo = 42' > foo.sc
+
+./scala-repl-pp --predef foo.sc
 scala> foo
 val res0: Int = 42
 ```
@@ -127,28 +127,7 @@ println("Hello!")
 ./scala-repl-pp --script test-simple.sc
 ```
 
-### Predef code for script
-test-predef.sc
-```scala
-println(foo)
-```
-
-```bash
-./scala-repl-pp --script test-predef.sc --predefCode 'val foo = "Hello, predef!"'
-```
-
-### Predef code via environment variable
-test-predef.sc
-```scala
-println(foo)
-```
-
-```bash
-export SCALA_REPL_PP_PREDEF_CODE='val foo = "Hello, predef!"'
-./scala-repl-pp --script test-predef.sc
-```
-
-### Predef file(s)
+### Predef file(s) used in script
 test-predef.sc
 ```scala
 println(foo)
@@ -285,31 +264,24 @@ stringcalc> add(One, Two)
 val res0: stringcalc.Number = Number(3)
 ```
 
-## Predef code and scripts
-There's a variety of ways to define predef code, i.e. code that is being run before any given script:
+## Global predef file: `~/.scala-repl-pp.sc`
+Code that should be available across all scala-repl-pp sessions can be written into your local `~/.scala-repl-pp.sc`. 
 
 ```
 echo 'def bar = 90' > ~/.scala-repl-pp.sc
 echo 'def baz = 91' > script1.sc
 echo 'def bam = 92' > script2.sc
-export SCALA_REPL_PP_PREDEF_CODE='def bax = 93'
 
-./scala-repl-pp --predefCode='def foo = 42' --predef script1.sc --predef script2.sc
-
-scala> foo
-val res0: Int = 42
+./scala-repl-pp --predef script1.sc --predef script2.sc
 
 scala> bar
-val res1: Int = 90
+val res0: Int = 90
 
 scala> baz
-val res2: Int = 91
+val res1: Int = 91
 
 scala> bam
-val res3: Int = 92
-
-scala> bax
-val res4: Int = 93
+val res2: Int = 92
 ```
 
 ## Verbose mode

--- a/core/src/main/scala/replpp/Config.scala
+++ b/core/src/main/scala/replpp/Config.scala
@@ -3,9 +3,7 @@ package replpp
 import java.nio.file.Path
 
 case class Config(
-  predefCode: Option[String] = None,
   predefFiles: Seq[Path] = Nil,
-  predefFilesBeforePredefCode: Boolean = false,
   nocolors: Boolean = false,
   verbose: Boolean = false,
   dependencies: Seq[String] = Seq.empty,
@@ -32,10 +30,6 @@ case class Config(
   lazy val asJavaArgs: Seq[String] = {
     val args = Seq.newBuilder[String]
     def add(entries: String*) = args.addAll(entries)
-
-    predefCode.foreach { code =>
-      add("--predefCode", code)
-    }
 
     predefFiles.foreach { predefFile =>
       add("--predef", predefFile.toString)
@@ -68,11 +62,6 @@ object Config {
   def parse(args: Array[String]): Config = {
     val parser = new scopt.OptionParser[Config](getClass.getSimpleName) {
       override def errorOnUnknownArgument = false
-
-      opt[String]("predefCode")
-        .valueName("def foo = 42")
-        .action((x, c) => c.copy(predefCode = Option(x)))
-        .text("code to execute (quietly) on startup")
 
       opt[Path]('p', "predef")
         .valueName("myScript.sc")

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -106,9 +106,6 @@ package object replpp {
     resultLines.result().filterNot(_.trim.startsWith(UsingDirectives.FileDirective))
   }
 
-  private def lines(str: String): Seq[String] =
-    str.split(lineSeparator)
-
   /**
     * resolve absolute or relative paths to an absolute path
     * - if given pathStr is an absolute path, just take that

--- a/core/src/test/scala/replpp/ConfigTests.scala
+++ b/core/src/test/scala/replpp/ConfigTests.scala
@@ -11,7 +11,6 @@ class ConfigTests extends AnyWordSpec with Matchers {
 
   "asJavaArgs (inverse of Config.parse) for ScriptingDriver" in {
     val config = Config(
-      predefCode = Some("val predefCode = 42"),
       predefFiles = List(Paths.get("/some/path/predefFile1"), Paths.get("/some/path/predefFile2")),
       nocolors = true,
       verbose = true,
@@ -24,7 +23,6 @@ class ConfigTests extends AnyWordSpec with Matchers {
 
     val javaArgs = config.asJavaArgs
     javaArgs shouldBe Seq(
-      "--predefCode", "val predefCode = 42",
       "--predef", "/some/path/predefFile1",
       "--predef", "/some/path/predefFile2",
       "--nocolors",


### PR DESCRIPTION
RIP 'predefCode' parameter - downstream users need to pass files
now. This fixes problems when running scripts on windows, and also
decomplexifies things a lot. No more need for
`predefFilesBeforePredefCode` and a bunch of extra logic. I also dropped
the `SCALA_REPL_PP_PREDEF_CODE` env var while I was at it...