### PR TITLE
simplify rendering: we don't need reflection any longer, apparently

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,17 @@ println(bar) //1
 
 Unlike the stock Scala REPL, scala-repl-pp does _not_ truncate the output by default. You can optionally specify the maxHeight parameter though:
 ```
+
 ./scala-repl-pp --maxHeight 5
-scala> (1 to 100000).toSeq
-val res0: scala.collection.immutable.Range.Inclusive = Range(
-  1,
-  2,
-  3,
-...
+
+scala> (1 to 100000).map(_.toString).toSeq
+val res0: IndexedSeq[String] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9,
+ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+ 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+ 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+ 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+ 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+ 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 1...
 ```
 
 ## Scripting

--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -5,9 +5,9 @@ import scala.util.matching.Regex
 
 object PPrinter {
   private var pprinter: pprint.PPrinter = null
-  private var maxHeight: Int = Int.MaxValue
+  private var maxHeight: Option[Int] = None
 
-  def apply(objectToRender: Object, maxHeight: Int = Int.MaxValue): String = {
+  def apply(objectToRender: Object, maxHeight: Option[Int] = None): String = {
     val _pprinter = this.synchronized {
       // initialise on first use and whenever the maxHeight setting changed
       if (pprinter == null || this.maxHeight != maxHeight) {
@@ -19,9 +19,9 @@ object PPrinter {
     _pprinter.apply(objectToRender).render
   }
 
-  private def create(maxHeight: Int): pprint.PPrinter = {
+  private def create(maxHeight: Option[Int] = None): pprint.PPrinter = {
     new pprint.PPrinter(
-      defaultHeight = maxHeight,
+      defaultHeight = maxHeight.getOrElse(Int.MaxValue),
       colorLiteral = fansi.Attrs.Empty, // leave color highlighting to the repl
       colorApplyPrefix = fansi.Attrs.Empty) {
 

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -37,7 +37,11 @@ class ReplDriver(args: Array[String],
     val terminal = new JLineTerminal {
       override protected def promptStr = prompt
     }
-    initializeRenderer()
+
+    // configure rendering to use our pprinter for displaying results
+    rendering.myReplStringOf = (objectToRender: Object, maxElements: Int, maxCharacters: Int) =>
+      PPrinter.apply(objectToRender, maxHeight)
+
     greeting.foreach(out.println)
 
     @tailrec
@@ -116,12 +120,5 @@ class ReplDriver(args: Array[String],
 
   private def parseInput(input: String, state: State): ParseResult =
     ParseResult(input)(using state)
-
-  /** configure rendering to use our pprinter for displaying results */
-  private def initializeRenderer() = {
-    rendering.myReplStringOf = (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
-      PPrinter.apply(objectToRender, maxHeight.getOrElse(Int.MaxValue))
-    }
-  }
 
 }

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -119,15 +119,8 @@ class ReplDriver(args: Array[String],
 
   /** configure rendering to use our pprinter for displaying results */
   private def initializeRenderer() = {
-    rendering.myReplStringOf = {
-      // We need to use the PPrinter class from the on the user classpath, and not the one available in the current
-      // classloader, so we use reflection instead of simply calling `replpp.PPrinter:apply`.
-      // This is analogous to what happens in dotty.tools.repl.Rendering.
-      val pprinter = Class.forName("replpp.PPrinter", true, rendering.myClassLoader)
-      val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int])
-      (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
-        renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue)).asInstanceOf[String]
-      }
+    rendering.myReplStringOf = (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
+      PPrinter.apply(objectToRender, maxHeight.getOrElse(Int.MaxValue))
     }
   }
 


### PR DESCRIPTION
* I guess we only needed that while we used the stock repl renderer...
* refactor: simplify, use Option for Optional value - reflection made that difficult previously