### PR TITLE
pprint-based rendering: colors and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,17 @@ Scala REPL PlusPlus: a better Scala 3 REPL. With many features inspired by ammon
 
 ### Regular Scala REPL
 * add runtime dependencies on startup with maven coordinates - automatically handles all downstream dependencies via [coursier](https://get-coursier.io/)
-* pretty printing via [pprint](https://com-lihaoyi.github.io/PPrint/)
 * customize greeting, prompt and shutdown code
 * multiple @main with named arguments (regular Scala REPL only allows an argument list)
 * predef code - i.e. run custom code before starting the REPL - via string and scripts
 * server mode: REPL runs embedded
 * easily embeddable into your own build
+* structured rendering including product labels and type information:<br/>
+Stock scala REPL:<br/>
+<img src="https://github.com/mpollmeier/scala-repl-pp/assets/506752/c564e4c1-6e78-4b9c-8d2f-749fedeb7db6" width="700px"/>
+<br/>
+Scala-REPL-PP:<br/>
+<img src="https://github.com/mpollmeier/scala-repl-pp/assets/506752/e31a06b2-4909-4370-a3f9-ea48da7f093a" width="700px"/>
 
 ### [Ammonite](http://ammonite.io)
 * Ammonite's Scala 3 support is far from complete - e.g. autocompletion for extension methods has [many shortcomings](https://github.com/com-lihaoyi/Ammonite/issues/1297). In comparison: scala-repl-pp uses the regular Scala3/dotty ReplDriver. 

--- a/README.md
+++ b/README.md
@@ -119,17 +119,13 @@ println(bar) //1
 
 Unlike the stock Scala REPL, scala-repl-pp does _not_ truncate the output by default. You can optionally specify the maxHeight parameter though:
 ```
-
 ./scala-repl-pp --maxHeight 5
-
-scala> (1 to 100000).map(_.toString).toSeq
-val res0: IndexedSeq[String] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9,
- 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
- 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
- 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
- 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
- 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
- 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 1...
+scala> (1 to 100000).toSeq
+val res0: scala.collection.immutable.Range.Inclusive = Range(
+  1,
+  2,
+  3,
+...
 ```
 
 ## Scripting

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -44,8 +44,10 @@ import scala.util.Using
  * Main REPL instance, orchestrating input, compilation and presentation
  * */
 class DottyReplDriver(settings: Array[String],
-                 out: PrintStream = Console.out,
-                 classLoader: Option[ClassLoader] = None) extends Driver:
+                      out: PrintStream,
+                      maxHeight: Option[Int],
+                      nocolors: Boolean,
+                      classLoader: Option[ClassLoader]) extends Driver:
 
   /** Overridden to `false` in order to not have to give sources on the
    *  commandline
@@ -88,7 +90,7 @@ class DottyReplDriver(settings: Array[String],
       rootCtx = rootCtx.fresh
         .setSetting(rootCtx.settings.outputDir, new VirtualDirectory("<REPL compilation output>"))
     compiler = new ReplCompiler
-    rendering = new Rendering(classLoader)
+    rendering = new Rendering(maxHeight, nocolors, classLoader)
   }
 
   private var rootCtx: Context = _

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -404,13 +404,48 @@ class DottyReplDriver(settings: Array[String],
           val formattedTypeDefs =  // don't render type defs if wrapper initialization failed
             if newState.invalidObjectIndexes.contains(state.objectIndex) then Seq.empty
             else typeDefs(wrapperModule.symbol)
-          val highlightedTypeDefs = formattedTypeDefs.map { d =>
-            new Diagnostic(d.msg.mapMsg(SyntaxHighlighting.highlight), d.pos, d.level)
-          }
-          val highlightedMembers = formattedMembers.map { d =>
-            new Diagnostic(d.msg, d.pos, d.level)
-          }
-          val highlighted = highlightedTypeDefs ++ highlightedMembers
+          val highlighted = (formattedTypeDefs ++ formattedMembers)
+//            .map(d => new Diagnostic(d.msg.mapMsg(SyntaxHighlighting.highlight), d.pos, d.level))
+          // TODO refactor
+            .map(d => new Diagnostic(d.msg.mapMsg { msg =>
+              if (PPrinter.isAnsiEncoded(msg)) {
+                // output already contains ansi color encodings - that's going to mess with the Scanner used by
+                // SyntaxHighlighting, so we'll remember the used colors here, reset the color coding of the input,
+                // and reapply those old colors in the end
+
+                val original = fansi.Str(msg)
+                val dottyHighlighted = fansi.Str(SyntaxHighlighting.highlight(original.plainText))
+                assert(original.length == dottyHighlighted.length, s"something went wrong, the length of the string changed...")
+                var result = dottyHighlighted
+
+                // reapply previous colors
+                // TODO refactor: build Seq[Attr] for overlays and call dottyHighlighted.overlayAll
+                // scanWhile, takeWhile, partition, ...
+                // dottyHighlighted.overlayAll()
+                for (idx <- 0 until original.length) {
+                  val colorAtIdx = original.getColor(idx)
+                  if (colorAtIdx != 0L) {
+                    // TODO get the right color here...
+                    // understand where that color is coming from...
+//                    val green = fansi.Color.Red
+//                    val x0 = fansi.Color.mask
+//                    val x1 = fansi.Color.makeAttr("abc", colorAtIdx)
+//                    val x2 = fansi.Color.makeNoneAttr(colorAtIdx)
+                    val ansiCodes = fansi.Attrs.emitAnsiCodes(original.getColor(idx - 1), colorAtIdx)
+                    // idea: with this one could manually stitch together then result string... that's a workaround if we don't find the fansi method to do this nicely
+
+//                    fansi.Color(0)
+                    result = result.overlay(fansi.Color.Green, idx, idx + 1)
+                  }
+                }
+
+                result.render
+//                dottyHighlighted.render
+              } else {
+                SyntaxHighlighting.highlight(msg)
+              }
+            }, d.pos, d.level))
+          // TODO debug code end
           (newState, highlighted)
         }
         .getOrElse {

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -404,8 +404,13 @@ class DottyReplDriver(settings: Array[String],
           val formattedTypeDefs =  // don't render type defs if wrapper initialization failed
             if newState.invalidObjectIndexes.contains(state.objectIndex) then Seq.empty
             else typeDefs(wrapperModule.symbol)
-          val highlighted = (formattedTypeDefs ++ formattedMembers)
-            .map(d => new Diagnostic(d.msg.mapMsg(SyntaxHighlighting.highlight), d.pos, d.level))
+          val highlightedTypeDefs = formattedTypeDefs.map { d =>
+            new Diagnostic(d.msg.mapMsg(SyntaxHighlighting.highlight), d.pos, d.level)
+          }
+          val highlightedMembers = formattedMembers.map { d =>
+            new Diagnostic(d.msg, d.pos, d.level)
+          }
+          val highlighted = highlightedTypeDefs ++ highlightedMembers
           (newState, highlighted)
         }
         .getOrElse {

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -39,7 +39,7 @@ import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
 import scala.util.Using
-import replpp.util.{findAdjacentNumberRanges, Range}
+import replpp.util.{findAdjacentNumberRanges, InclusiveRange}
 
 /** Based on https://github.com/lampepfl/dotty/blob/3.3.0-RC5/compiler/src/dotty/tools/repl/ReplDriver.scala
  * Main REPL instance, orchestrating input, compilation and presentation
@@ -442,7 +442,7 @@ class DottyReplDriver(settings: Array[String],
     assert(previouslyHighlighted.length == dottyHighlighted.length,
       s"something went wrong in SyntaxHighlighting.highlight, the length of the highlighted messages must be identical but isn't: ${previouslyHighlighted.length} (previously) vs ${dottyHighlighted.length} (dotty highlighted)")
 
-    val coloredCharRangesInOriginal: Seq[Range] = {
+    val coloredCharRangesInOriginal: Seq[InclusiveRange] = {
       val coloredPositions = previouslyHighlighted.getColors.zipWithIndex.collect { case (color, index) if color != 0 => index }
       findAdjacentNumberRanges(coloredPositions)
     }
@@ -452,7 +452,7 @@ class DottyReplDriver(settings: Array[String],
     var previouslyHighlightedBuffer = previouslyHighlighted
     var dottyBuffer = dottyHighlighted
     var currentIndex = 0
-    coloredCharRangesInOriginal.foreach { case Range(from, to) =>
+    coloredCharRangesInOriginal.foreach { case InclusiveRange(from, to) =>
       if (from > currentIndex) {
         // first take from dottyHighlighted until `range.from`
         val splitPosition = from - currentIndex

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -409,9 +409,13 @@ class DottyReplDriver(settings: Array[String],
           // TODO refactor
             .map(d => new Diagnostic(d.msg.mapMsg { msg =>
               if (PPrinter.isAnsiEncoded(msg)) {
-                // output already contains ansi color encodings - that's going to mess with the Scanner used by
+                // `msg` already contains ansi color encodings - that's going to mess with the Scanner used by
                 // SyntaxHighlighting, so we'll remember the used colors here, reset the color coding of the input,
-                // and reapply those old colors in the end
+                // and reapply those old colors in the end.
+                // Going forward it'd be much better if the dotty repl was rendering the objects directly, rather than
+                // just highlighting the result string. That way we have all type information, product element labels
+                // etc still available... my intention is to create a PR on the dotty repo for that, but first need
+                // to iron out things here.
 
                 val pprinted = fansi.Str(msg)
                 val dottyHighlighted = fansi.Str(SyntaxHighlighting.highlight(pprinted.plainText))

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -414,35 +414,58 @@ class DottyReplDriver(settings: Array[String],
                 // SyntaxHighlighting, so we'll remember the used colors here, reset the color coding of the input,
                 // and reapply those old colors in the end
 
-                val original = fansi.Str(msg)
-                val dottyHighlighted = fansi.Str(SyntaxHighlighting.highlight(original.plainText))
-                assert(original.length == dottyHighlighted.length, s"something went wrong, the length of the string changed...")
+                val pprinted = fansi.Str(msg)
+                val dottyHighlighted = fansi.Str(SyntaxHighlighting.highlight(pprinted.plainText))
+                assert(pprinted.length == dottyHighlighted.length, s"something went wrong, the length of the string changed...")
 
-                // merge the two fansi.Str - prefer the original where it's color coded, otherwise take the dottyHighlighted
                 val coloredCharRangesInOriginal: Seq[Range] = {
-                  val coloredPositions = original.getColors.zipWithIndex.collect {
+                  val coloredPositions = pprinted.getColors.zipWithIndex.collect {
                     case (color, index) if color != 0 => index
                   }
                   findAdjacentNumberRanges(coloredPositions)
                 }
 
-                coloredCharRangesInOriginal.foreach(println)
-                val result = fansi.Str()
-//                for (idx <- 0 until original.length) {
-//
-//                }
+                // merge the two fansi.Str - prefer the pprinted where it's color coded, otherwise take the dottyHighlighted
+                // TODO refactor: extract method, variable wording, extract 'scanLeft' or 'takeUntil'
+                // TODO add unit tests for all combinations: color only in dotty, color only in pprinted, color first in pprinted, color first in dotty
+                var result = fansi.Str()
+                var pprintedBuffer = pprinted
+                var dottyBuffer = dottyHighlighted
+                var currentIndex = 0
+                println("pprinted: " + pprinted)
+                println("dottyHighlighted: " + dottyHighlighted)
+                println("coloredRanges: " + coloredCharRangesInOriginal)
+                coloredCharRangesInOriginal.foreach { case Range(from, to) =>
+                  if (from > currentIndex) {
+                    // first take from dottyHighlighted until `range.from`
+                    val splitPosition = from - currentIndex
+                    val (takenFromDotty, dottyRemainder) = dottyBuffer.splitAt(splitPosition)
+                    result = result ++ takenFromDotty
+                    dottyBuffer = dottyRemainder
+                    pprintedBuffer = pprintedBuffer.substring(start = splitPosition)
+                    currentIndex = from
+                  }
 
-//                original.splitAt()
+                  // then take range length from pprinted (either way)
+                  val splitPosition = to + 1 - currentIndex
+                  val (takenFromPPrinted, pprintedRemainder) = pprintedBuffer.splitAt(splitPosition)
+                  result = result ++ takenFromPPrinted
+                  pprintedBuffer = pprintedRemainder
+                  dottyBuffer = dottyBuffer.substring(start = splitPosition)
+
+                  currentIndex = to + 1
+                }
+                result = result ++ dottyBuffer
 
 //                var result = dottyHighlighted
-//                println(original.getColors.toSeq)
+//                println(pprinted.getColors.toSeq)
 //
 //                // reapply previous colors
 //                // TODO refactor: build Seq[Attr] for overlays and call dottyHighlighted.overlayAll
 //                // scanWhile, takeWhile, partition, ...
 //                // dottyHighlighted.overlayAll()
-//                for (idx <- 0 until original.length) {
-//                  val colorAtIdx = original.getColor(idx)
+//                for (idx <- 0 until pprinted.length) {
+//                  val colorAtIdx = pprinted.getColor(idx)
 //                  if (colorAtIdx != 0L) {
 //                    // TODO get the right color here...
 //                    // understand where that color is coming from...
@@ -450,7 +473,7 @@ class DottyReplDriver(settings: Array[String],
 ////                    val x0 = fansi.Color.mask
 ////                    val x1 = fansi.Color.makeAttr("abc", colorAtIdx)
 ////                    val x2 = fansi.Color.makeNoneAttr(colorAtIdx)
-//                    val ansiCodes = fansi.Attrs.emitAnsiCodes(original.getColor(idx - 1), colorAtIdx)
+//                    val ansiCodes = fansi.Attrs.emitAnsiCodes(pprinted.getColor(idx - 1), colorAtIdx)
 //                    // idea: with this one could manually stitch together then result string... that's a workaround if we don't find the fansi method to do this nicely
 //                    result = result.overlay(fansi.Color.Green, idx, idx + 1)
 //                  }

--- a/core/src/main/scala/replpp/InteractiveShell.scala
+++ b/core/src/main/scala/replpp/InteractiveShell.scala
@@ -17,7 +17,8 @@ object InteractiveShell {
       onExitCode = config.onExitCode,
       greeting = Option(config.greeting),
       prompt = config.prompt.getOrElse("scala"),
-      maxHeight = config.maxHeight
+      maxHeight = config.maxHeight,
+      nocolors = config.nocolors
     )
 
     val initialState: State = replDriver.initialState

--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -6,13 +6,15 @@ import scala.util.matching.Regex
 object PPrinter {
   private var pprinter: pprint.PPrinter = null
   private var maxHeight: Int = Int.MaxValue
+  private var nocolors: Boolean = false
 
-  def apply(objectToRender: Object, maxHeight: Int = Int.MaxValue, noColors: Boolean = false): String = {
+  def apply(objectToRender: Object, maxHeight: Int = Int.MaxValue, nocolors: Boolean = false): String = {
     val _pprinter = this.synchronized {
       // initialise on first use and whenever the maxHeight setting changed
-      if (pprinter == null || this.maxHeight != maxHeight) {
-        pprinter = create(maxHeight, noColors)
+      if (pprinter == null || this.maxHeight != maxHeight || this.nocolors != nocolors) {
+        pprinter = create(maxHeight, nocolors)
         this.maxHeight = maxHeight
+        this.nocolors = nocolors
       }
       pprinter
     }

--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -5,9 +5,9 @@ import scala.util.matching.Regex
 
 object PPrinter {
   private var pprinter: pprint.PPrinter = null
-  private var maxHeight: Option[Int] = None
+  private var maxHeight: Int = Int.MaxValue
 
-  def apply(objectToRender: Object, maxHeight: Option[Int] = None): String = {
+  def apply(objectToRender: Object, maxHeight: Int = Int.MaxValue): String = {
     val _pprinter = this.synchronized {
       // initialise on first use and whenever the maxHeight setting changed
       if (pprinter == null || this.maxHeight != maxHeight) {
@@ -19,9 +19,9 @@ object PPrinter {
     _pprinter.apply(objectToRender).render
   }
 
-  private def create(maxHeight: Option[Int] = None): pprint.PPrinter = {
+  private def create(maxHeight: Int): pprint.PPrinter = {
     new pprint.PPrinter(
-      defaultHeight = maxHeight.getOrElse(Int.MaxValue),
+      defaultHeight = maxHeight,
       colorLiteral = fansi.Attrs.Empty, // leave color highlighting to the repl
       colorApplyPrefix = fansi.Attrs.Empty) {
 

--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -51,9 +51,8 @@ object PPrinter {
     }
   }
 
-  val AnsiEncodedRegexp: Regex = "\u001b\\[[\\d;]+m".r
-  def isAnsiEncoded(s: String): Boolean =
-    AnsiEncodedRegexp.findFirstIn(s).isDefined
+  def isAnsiEncoded(string: String): Boolean =
+    string.exists(c => c == '\u001b' || c == '\u009b')
 
   /** We use source-highlight to encode source as ansi strings, e.g. the .dump step Ammonite uses fansi for it's
     * colour-coding, and while both pledge to follow the ansi codec, they aren't compatible TODO: PR for fansi to

--- a/core/src/main/scala/replpp/Rendering.scala
+++ b/core/src/main/scala/replpp/Rendering.scala
@@ -23,7 +23,9 @@ import scala.util.control.NonFatal
  *       `ReplDriver#resetToInitial` is called, the accompanying instance of
  *       `Rendering` is no longer valid.
  */
-private[replpp] class Rendering(parentClassLoader: Option[ClassLoader] = None):
+private[replpp] class Rendering(maxHeight: Option[Int],
+                                nocolors: Boolean,
+                                parentClassLoader: Option[ClassLoader] = None):
 
   import Rendering._
 
@@ -50,47 +52,19 @@ private[replpp] class Rendering(parentClassLoader: Option[ClassLoader] = None):
 
       myClassLoader = new AbstractFileClassLoader(ctx.settings.outputDir.value, parent)
       myReplStringOf = {
-        // We need to use the ScalaRunTime class coming from the scala-library
-        // on the user classpath, and not the one available in the current
-        // classloader, so we use reflection instead of simply calling
-        // `ScalaRunTime.replStringOf`. Probe for new API without extraneous newlines.
-        // For old API, try to clean up extraneous newlines by stripping suffix and maybe prefix newline.
-        val scalaRuntime = Class.forName("scala.runtime.ScalaRunTime", true, myClassLoader)
-        val renderer = "stringOf"
-        def stringOfMaybeTruncated(value: Object, maxElements: Int): String = {
-          try {
-            val meth = scalaRuntime.getMethod(renderer, classOf[Object], classOf[Int], classOf[Boolean])
-            val truly = java.lang.Boolean.TRUE
-            meth.invoke(null, value, maxElements, truly).asInstanceOf[String]
-          } catch {
-            case _: NoSuchMethodException =>
-              val meth = scalaRuntime.getMethod(renderer, classOf[Object], classOf[Int])
-              meth.invoke(null, value, maxElements).asInstanceOf[String]
-          }
+        /** this part was rewritten for replpp: use our very own pprinter for displaying results
+          * We need to use the PPrinter class from the on the user classpath, and not the one available in the current
+          * classloader, so we use reflection instead of simply calling `replpp.PPrinter:apply`.
+          * This is analogous to what happens in dotty.tools.repl.Rendering.
+          **/
+        val pprinter = Class.forName("replpp.PPrinter", true, myClassLoader)
+        val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int], classOf[Boolean])
+        (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
+          renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue), nocolors).asInstanceOf[String]
         }
-
-        (value: Object, maxElements: Int, maxCharacters: Int) => {
-          // `ScalaRuntime.stringOf` may truncate the output, in which case we want to indicate that fact to the user
-          // In order to figure out if it did get truncated, we invoke it twice - once with the `maxElements` that we
-          // want to print, and once without a limit. If the first is shorter, truncation did occur.
-          val notTruncated = stringOfMaybeTruncated(value, Int.MaxValue)
-          val maybeTruncatedByElementCount = stringOfMaybeTruncated(value, maxElements)
-          val maybeTruncated = truncate(maybeTruncatedByElementCount, maxCharacters)
-
-          // our string representation may have been truncated by element and/or character count
-          // if so, append an info string - but only once
-          if (notTruncated.length == maybeTruncated.length) maybeTruncated
-          else s"$maybeTruncated ... large output truncated, print value to show all"
-        }
-
       }
       myClassLoader
     }
-
-  private[replpp] def truncate(str: String, maxPrintCharacters: Int)(using ctx: Context): String =
-    val ncp = str.codePointCount(0, str.length) // to not cut inside code point
-    if ncp <= maxPrintCharacters then str
-    else str.substring(0, str.offsetByCodePoints(0, maxPrintCharacters - 1))
 
   /** Return a String representation of a value we got from `classLoader()`. */
   private[replpp] def replStringOf(value: Object)(using Context): String =

--- a/core/src/main/scala/replpp/Rendering.scala
+++ b/core/src/main/scala/replpp/Rendering.scala
@@ -59,10 +59,6 @@ private[replpp] class Rendering(maxHeight: Option[Int],
           **/
         val pprinter = Class.forName("replpp.PPrinter", true, myClassLoader)
         val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int], classOf[Boolean])
-        // TODO only for testing - dont commit
-//        val scalaRuntime = Class.forName("scala.runtime.ScalaRunTime", true, myClassLoader)
-//        val renderer = "stringOf"
-//        val renderingMethod  = scalaRuntime.getMethod(renderer, classOf[Object], classOf[Int])
         (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
           renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue), nocolors).asInstanceOf[String]
         }

--- a/core/src/main/scala/replpp/Rendering.scala
+++ b/core/src/main/scala/replpp/Rendering.scala
@@ -59,6 +59,10 @@ private[replpp] class Rendering(maxHeight: Option[Int],
           **/
         val pprinter = Class.forName("replpp.PPrinter", true, myClassLoader)
         val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int], classOf[Boolean])
+        // TODO only for testing - dont commit
+//        val scalaRuntime = Class.forName("scala.runtime.ScalaRunTime", true, myClassLoader)
+//        val renderer = "stringOf"
+//        val renderingMethod  = scalaRuntime.getMethod(renderer, classOf[Object], classOf[Int])
         (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
           renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue), nocolors).asInstanceOf[String]
         }

--- a/core/src/main/scala/replpp/Rendering.scala
+++ b/core/src/main/scala/replpp/Rendering.scala
@@ -52,10 +52,16 @@ private[replpp] class Rendering(maxHeight: Option[Int],
 
       myClassLoader = new AbstractFileClassLoader(ctx.settings.outputDir.value, parent)
       myReplStringOf = {
-        /** this part was rewritten for replpp: use our very own pprinter for displaying results
-          * We need to use the PPrinter class from the on the user classpath, and not the one available in the current
-          * classloader, so we use reflection instead of simply calling `replpp.PPrinter:apply`.
-          * This is analogous to what happens in dotty.tools.repl.Rendering.
+        /**
+          * The stock Scala REPL's rendering is suboptimal:
+          * - it doesn't format the output for better readability
+          * - the color highlighting is based on the string representation, i.e. a lot of information
+          *   about the value it wants to render is lost, such as product labels, type information etc. 
+          * Therefor this part was rewritten for replpp. 
+          * 
+          * Just like in the regular REPL (see dotty.tools.repl.Rendering), we need to use the PPrinter class
+          * from the on the user classpath, and not the one available in the current classloader, so we
+          * use reflection instead of simply calling `replpp.PPrinter:apply`.
           **/
         val pprinter = Class.forName("replpp.PPrinter", true, myClassLoader)
         val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int], classOf[Boolean])

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -37,11 +37,7 @@ class ReplDriver(args: Array[String],
     val terminal = new JLineTerminal {
       override protected def promptStr = prompt
     }
-
-    // configure rendering to use our pprinter for displaying results
-    rendering.myReplStringOf = (objectToRender: Object, maxElements: Int, maxCharacters: Int) =>
-      PPrinter.apply(objectToRender, maxHeight)
-
+    initializeRenderer()
     greeting.foreach(out.println)
 
     @tailrec
@@ -80,6 +76,20 @@ class ReplDriver(args: Array[String],
       candidates.addAll(comps.asJava)
     }
     terminal.readLine(completer).linesIterator
+  }
+
+  /** configure rendering to use our pprinter for displaying results */
+  private def initializeRenderer() = {
+    rendering.myReplStringOf = {
+      // We need to use the PPrinter class from the on the user classpath, and not the one available in the current
+      // classloader, so we use reflection instead of simply calling `replpp.PPrinter:apply`.
+      // This is analogous to what happens in dotty.tools.repl.Rendering.
+      val pprinter = Class.forName("replpp.PPrinter", true, rendering.myClassLoader)
+      val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int])
+      (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
+        renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue)).asInstanceOf[String]
+      }
+    }
   }
 
 }

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -28,6 +28,7 @@ class ReplDriver(args: Array[String],
                  greeting: Option[String],
                  prompt: String,
                  maxHeight: Option[Int] = None,
+                 nocolors: Boolean = false,
                  classLoader: Option[ClassLoader] = None) extends ReplDriverBase(args, out, classLoader) {
 
   /** Run REPL with `state` until `:quit` command found
@@ -85,9 +86,9 @@ class ReplDriver(args: Array[String],
       // classloader, so we use reflection instead of simply calling `replpp.PPrinter:apply`.
       // This is analogous to what happens in dotty.tools.repl.Rendering.
       val pprinter = Class.forName("replpp.PPrinter", true, rendering.myClassLoader)
-      val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int])
+      val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int], classOf[Boolean])
       (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
-        renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue)).asInstanceOf[String]
+        renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue), nocolors).asInstanceOf[String]
       }
     }
   }

--- a/core/src/main/scala/replpp/ReplDriverBase.scala
+++ b/core/src/main/scala/replpp/ReplDriverBase.scala
@@ -23,8 +23,12 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
-abstract class ReplDriverBase(args: Array[String], out: PrintStream, classLoader: Option[ClassLoader])
-  extends DottyReplDriver(args, out, classLoader) {
+abstract class ReplDriverBase(args: Array[String],
+                              out: PrintStream,
+                              maxHeight: Option[Int],
+                              nocolors: Boolean,
+                              classLoader: Option[ClassLoader])
+  extends DottyReplDriver(args, out, maxHeight, nocolors, classLoader) {
 
   protected def interpretInput(lines: IterableOnce[String], state: State, currentFile: Path): State = {
     val parsedLines = Seq.newBuilder[String]

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -7,7 +7,33 @@ import scala.jdk.CollectionConverters.*
 import scala.util.{Try, Using}
 
 package object util {
-  
+
+  /** `to` is included in this Range */
+  case class Range(from: Int, to: Int)
+
+  def findAdjacentNumberRanges(numbers: Seq[Int]): Seq[Range] = {
+    if (numbers.isEmpty) {
+      Seq.empty
+    } else {
+      var start = numbers(0)
+      var end = numbers(0)
+      val ranges = Seq.newBuilder[Range]
+
+      for (i <- 1 until numbers.length) {
+        if (numbers(i) == end + 1) {
+          end = numbers(i)
+        } else {
+          ranges += Range(start, end)
+          start = numbers(i)
+          end = numbers(i)
+        }
+      }
+
+      ranges += Range(start, end)
+      ranges.result()
+    }
+  }
+
   def sequenceTry[A](tries: Seq[Try[A]]): Try[Seq[A]] = {
     tries.foldRight(Try(Seq.empty[A])) {
       case (next, accumulator) => 

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -8,28 +8,28 @@ import scala.util.{Try, Using}
 
 package object util {
 
-  /** `to` is included in this Range */
-  case class Range(from: Int, to: Int)
+  /** both `to` and `from` are included in this Range */
+  case class InclusiveRange(from: Int, to: Int)
 
-  def findAdjacentNumberRanges(numbers: Seq[Int]): Seq[Range] = {
+  def findAdjacentNumberRanges(numbers: Seq[Int]): Seq[InclusiveRange] = {
     if (numbers.isEmpty) {
       Seq.empty
     } else {
       var start = numbers(0)
       var end = numbers(0)
-      val ranges = Seq.newBuilder[Range]
+      val ranges = Seq.newBuilder[InclusiveRange]
 
       for (i <- 1 until numbers.length) {
         if (numbers(i) == end + 1) {
           end = numbers(i)
         } else {
-          ranges += Range(start, end)
+          ranges += InclusiveRange(start, end)
           start = numbers(i)
           end = numbers(i)
         }
       }
 
-      ranges += Range(start, end)
+      ranges += InclusiveRange(start, end)
       ranges.result()
     }
   }

--- a/core/src/test/scala/replpp/PPrinterTests.scala
+++ b/core/src/test/scala/replpp/PPrinterTests.scala
@@ -10,21 +10,24 @@ import org.scalatest.wordspec.AnyWordSpec
 class PPrinterTests extends AnyWordSpec with Matchers {
 
   "print some common datastructures" in {
-    PPrinter(List(1, 2), nocolors = true) shouldBe "List(1, 2)"
-    replaceColorEncodingForTest(
-      PPrinter(List(1,2))
-    ) shouldBe "<Y|List>(<G|1>, <G|2>)"
+    testRendering(
+      List(1, 2),
+      expectedUncolored = "List(1, 2)",
+      expectedColored = "<Y|List>(<G|1>, <G|2>)"
+    )
 
-    PPrinter((1,2,"three"), nocolors = true)  shouldBe """(1, 2, "three")"""
-    replaceColorEncodingForTest(
-      PPrinter((1, 2, "three"))
-    ) shouldBe """(<G|1>, <G|2>, <G|"three">)"""
+    testRendering(
+      (1,2,"three"),
+      expectedUncolored = """(1, 2, "three")""",
+      expectedColored = """(<G|1>, <G|2>, <G|"three">)"""
+    )
 
     case class A(i: Int, s: String)
-    PPrinter(A(42, "foo bar"), nocolors = true)  shouldBe """A(i = 42, s = "foo bar")"""
-    replaceColorEncodingForTest(
-      PPrinter(A(42, "foo bar"))
-    ) shouldBe """<Y|A>(i = <G|42>, s = <G|"foo bar">)"""
+    testRendering(
+      A(42, "foo bar"),
+      expectedUncolored = """A(i = 42, s = "foo bar")""",
+      expectedColored = """<Y|A>(i = <G|42>, s = <G|"foo bar">)"""
+    )
 
     val productWithLabels = new Product {
       override def productPrefix = "Foo"
@@ -44,10 +47,12 @@ class PPrinterTests extends AnyWordSpec with Matchers {
 
       def canEqual(that: Any): Boolean = ???
     }
-    PPrinter(productWithLabels, nocolors = true) shouldBe """Foo(first = "one", second = "two")"""
-    replaceColorEncodingForTest(
-      PPrinter(productWithLabels)
-    )shouldBe """<Y|Foo>(first = <G|"one">, second = <G|"two">)"""
+
+    testRendering(
+      productWithLabels,
+      expectedUncolored = """Foo(first = "one", second = "two")""",
+      expectedColored = """<Y|Foo>(first = <G|"one">, second = <G|"two">)"""
+    )
   }
 
   "fansi encoding fix" must {
@@ -84,6 +89,13 @@ class PPrinterTests extends AnyWordSpec with Matchers {
     lazy val IfBlueBold = "\u001b[01;34mif\u001b[m"
     lazy val FBold = "\u001b[01mF\u001b[m"
     lazy val X8bit = "\u001b[00;38;05;70mX\u001b[m"
+  }
+
+  def testRendering(value: AnyRef, expectedUncolored: String, expectedColored: String): Unit = {
+    PPrinter(value, nocolors = true) shouldBe expectedUncolored
+
+    val resultColored = PPrinter(value)
+    replaceColorEncodingForTest(resultColored) shouldBe expectedColored
   }
 
   // adapted from dotty SyntaxHighlightingTests

--- a/server/src/main/scala/replpp/server/EmbeddedRepl.scala
+++ b/server/src/main/scala/replpp/server/EmbeddedRepl.scala
@@ -83,7 +83,7 @@ class EmbeddedRepl(predefLines: IterableOnce[String] = Seq.empty) {
 }
 
 class ReplDriver(args: Array[String], out: PrintStream, classLoader: Option[ClassLoader])
-  extends ReplDriverBase(args, out, classLoader) {
+  extends ReplDriverBase(args, out, maxHeight = None, nocolors = true, classLoader) {
   def execute(inputLines: IterableOnce[String])(using state: State = initialState): State =
     interpretInput(inputLines, state, pwd)
 }


### PR DESCRIPTION
The stock scala repl's rendering is suboptimal:
* it doesn't format the output for better readability
* the color highlighting is based on the string representation, i.e. a lot of information about the value it wants to render is lost, such as product labels, type information etc. 

This PR fixes both aspects - the results look pretty neat IMO:

Stock scala REPL:
![image](https://github.com/mpollmeier/scala-repl-pp/assets/506752/c564e4c1-6e78-4b9c-8d2f-749fedeb7db6)

Scala-REPL-PP:
![image](https://github.com/mpollmeier/scala-repl-pp/assets/506752/e31a06b2-4909-4370-a3f9-ea48da7f093a)

My intention is to bring this (or some variant) into upstream dotty. 
