### PR TITLE
stop merging rendering results between dotty and pprint: too slow

### DIFF
--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -8,32 +8,6 @@ import scala.util.{Try, Using}
 
 package object util {
 
-  /** both `to` and `from` are included in this Range */
-  case class InclusiveRange(from: Int, to: Int)
-
-  def findAdjacentNumberRanges(numbers: Seq[Int]): Seq[InclusiveRange] = {
-    if (numbers.isEmpty) {
-      Seq.empty
-    } else {
-      var start = numbers(0)
-      var end = numbers(0)
-      val ranges = Seq.newBuilder[InclusiveRange]
-
-      for (i <- 1 until numbers.length) {
-        if (numbers(i) == end + 1) {
-          end = numbers(i)
-        } else {
-          ranges += InclusiveRange(start, end)
-          start = numbers(i)
-          end = numbers(i)
-        }
-      }
-
-      ranges += InclusiveRange(start, end)
-      ranges.result()
-    }
-  }
-
   def sequenceTry[A](tries: Seq[Try[A]]): Try[Seq[A]] = {
     tries.foldRight(Try(Seq.empty[A])) {
       case (next, accumulator) => 


### PR DESCRIPTION
For large outputs there's a long delay due to this merging of the
rendering. There may well be ways to optimise it, but I have different
plans.