### PR TITLE
input rendering: use same colors as in ammonite

### DIFF
--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -118,7 +118,7 @@ class DottyReplDriver(settings: Array[String],
    *  `protected final` to facilitate testing.
    */
   def runUntilQuit(using initialState: State = initialState)(): State = {
-    val terminal = new JLineTerminal
+    val terminal = new replpp.JLineTerminal
 
     out.println(
       s"""Welcome to Scala $simpleVersionString ($javaVersion, Java $javaVmName).

--- a/core/src/main/scala/replpp/JLineTerminal.scala
+++ b/core/src/main/scala/replpp/JLineTerminal.scala
@@ -29,12 +29,12 @@ class JLineTerminal extends java.io.Closeable {
   private val history = new DefaultHistory
   def dumbTerminal = Option(System.getenv("TERM")) == Some("dumb")
 
-  private def blue(str: String)(using Context) =
-    if (ctx.settings.color.value != "never") Console.BLUE + str + Console.RESET
+  private def promptColor(str: String)(using Context) =
+    if (ctx.settings.color.value != "never") Console.MAGENTA + str + Console.RESET
     else str
   protected def promptStr = "scala"
-  private def prompt(using Context)        = blue(s"\n$promptStr> ")
-  private def newLinePrompt(using Context) = blue("     | ")
+  private def prompt(using Context)        = promptColor(s"\n$promptStr> ")
+  private def newLinePrompt(using Context) = promptColor("     | ")
 
   /** Blockingly read line from `System.in`
    *

--- a/core/src/main/scala/replpp/JLineTerminal.scala
+++ b/core/src/main/scala/replpp/JLineTerminal.scala
@@ -1,0 +1,183 @@
+package replpp
+
+import scala.language.unsafeNulls
+import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.parsing.Scanners.Scanner
+import dotty.tools.dotc.parsing.Tokens.*
+import dotty.tools.dotc.printing.SyntaxHighlighting
+import dotty.tools.dotc.reporting.Reporter
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.repl.ParseResult
+import org.jline.reader
+import org.jline.reader.Parser.ParseContext
+import org.jline.reader.*
+import org.jline.reader.impl.LineReaderImpl
+import org.jline.reader.impl.history.DefaultHistory
+import org.jline.terminal.TerminalBuilder
+import org.jline.utils.AttributedString
+
+/** Based on https://github.com/lampepfl/dotty/blob/3.3.0-RC6/compiler/src/dotty/tools/repl/JLineTerminal.scala
+  * and adapted for our needs */
+class JLineTerminal extends java.io.Closeable {
+  // import java.util.logging.{Logger, Level}
+  // Logger.getLogger("org.jline").setLevel(Level.FINEST)
+
+  private val terminal =
+    TerminalBuilder.builder()
+    .dumb(dumbTerminal) // fail early if not able to create a terminal
+    .build()
+  private val history = new DefaultHistory
+  def dumbTerminal = Option(System.getenv("TERM")) == Some("dumb")
+
+  private def blue(str: String)(using Context) =
+    if (ctx.settings.color.value != "never") Console.BLUE + str + Console.RESET
+    else str
+  protected def promptStr = "scala"
+  private def prompt(using Context)        = blue(s"\n$promptStr> ")
+  private def newLinePrompt(using Context) = blue("     | ")
+
+  /** Blockingly read line from `System.in`
+   *
+   *  This entry point into JLine handles everything to do with terminal
+   *  emulation. This includes:
+   *
+   *  - Multi-line support
+   *  - Copy-pasting
+   *  - History
+   *  - Syntax highlighting
+   *  - Auto-completions
+   *
+   *  @throws EndOfFileException This exception is thrown when the user types Ctrl-D.
+   */
+  def readLine(
+    completer: Completer // provide auto-completions
+  )(using Context): String = {
+    import LineReader.Option._
+    import LineReader._
+    val userHome = System.getProperty("user.home")
+    val lineReader = LineReaderBuilder
+      .builder()
+      .terminal(terminal)
+      .history(history)
+      .completer(completer)
+      .highlighter(new Highlighter)
+      .parser(new Parser)
+      .variable(HISTORY_FILE, s"$userHome/.dotty_history") // Save history to file
+      .variable(SECONDARY_PROMPT_PATTERN, "%M") // A short word explaining what is "missing",
+                                                // this is supplied from the EOFError.getMissing() method
+      .variable(LIST_MAX, 400)                  // Ask user when number of completions exceed this limit (default is 100).
+      .variable(BLINK_MATCHING_PAREN, 0L)       // Don't blink the opening paren after typing a closing paren.
+      .variable(WORDCHARS,
+        LineReaderImpl.DEFAULT_WORDCHARS.filterNot("*?.[]~=/&;!#%^(){}<>".toSet)) // Finer grained word boundaries
+      .option(INSERT_TAB, true)                 // At the beginning of the line, insert tab instead of completing.
+      .option(AUTO_FRESH_LINE, true)            // if not at start of line before prompt, move to new line.
+      .option(DISABLE_EVENT_EXPANSION, true)    // don't process escape sequences in input
+      .build()
+
+    lineReader.readLine(prompt)
+  }
+
+  def close(): Unit = terminal.close()
+
+  /** Provide syntax highlighting */
+  private class Highlighter(using Context) extends reader.Highlighter {
+    def highlight(reader: LineReader, buffer: String): AttributedString = {
+      val highlighted = SyntaxHighlighting.highlight(buffer)
+      AttributedString.fromAnsi(highlighted)
+    }
+    def setErrorPattern(errorPattern: java.util.regex.Pattern): Unit = {}
+    def setErrorIndex(errorIndex: Int): Unit = {}
+  }
+
+  /** Provide multi-line editing support */
+  private class Parser(using Context) extends reader.Parser {
+
+    /**
+     * @param cursor     The cursor position within the line
+     * @param line       The unparsed line
+     * @param word       The current word being completed
+     * @param wordCursor The cursor position within the current word
+     */
+    private class ParsedLine(
+      val cursor: Int, val line: String, val word: String, val wordCursor: Int
+    ) extends reader.ParsedLine {
+      // Using dummy values, not sure what they are used for
+      def wordIndex = -1
+      def words = java.util.Collections.emptyList[String]
+    }
+
+    def parse(input: String, cursor: Int, context: ParseContext): reader.ParsedLine = {
+      def parsedLine(word: String, wordCursor: Int) =
+        new ParsedLine(cursor, input, word, wordCursor)
+      // Used when no word is being completed
+      def defaultParsedLine = parsedLine("", 0)
+
+      def incomplete(): Nothing = throw new EOFError(
+        // Using dummy values, not sure what they are used for
+        /* line    = */ -1,
+        /* column  = */ -1,
+        /* message = */ "",
+        /* missing = */ newLinePrompt)
+
+      case class TokenData(token: Token, start: Int, end: Int)
+      def currentToken: TokenData /* | Null */ = {
+        val source = SourceFile.virtual("<completions>", input)
+        val scanner = new Scanner(source)(using ctx.fresh.setReporter(Reporter.NoReporter))
+        var lastBacktickErrorStart: Option[Int] = None
+
+        while (scanner.token != EOF) {
+          val start = scanner.offset
+          val token = scanner.token
+          scanner.nextToken()
+          val end = scanner.lastOffset
+
+          val isCurrentToken = cursor >= start && cursor <= end
+          if (isCurrentToken)
+            return TokenData(token, lastBacktickErrorStart.getOrElse(start), end)
+
+
+          // we need to enclose the last backtick, which unclosed produces ERROR token
+          if (token == ERROR && input(start) == '`') then
+            lastBacktickErrorStart = Some(start)
+          else
+            lastBacktickErrorStart = None
+        }
+        null
+      }
+
+      def acceptLine = {
+        val onLastLine = !input.substring(cursor).contains(System.lineSeparator)
+        onLastLine && !ParseResult.isIncomplete(input)
+      }
+
+      context match {
+        case ParseContext.ACCEPT_LINE if acceptLine =>
+          // using dummy values, resulting parsed input is probably unused
+          defaultParsedLine
+
+        // In the situation where we have a partial command that we want to
+        // complete we need to ensure that the :<partial-word> isn't split into
+        // 2 tokens, but rather the entire thing is treated as the "word", in
+        //   order to insure the : is replaced in the completion.
+        case ParseContext.COMPLETE if
+          DottyRandomStuff.ParseResult.commands.exists(command => command._1.startsWith(input)) =>
+            parsedLine(input, cursor)
+
+        case ParseContext.COMPLETE =>
+          // Parse to find completions (typically after a Tab).
+          def isCompletable(token: Token) = isIdentifier(token) || isKeyword(token)
+          currentToken match {
+            case TokenData(token, start, end) if isCompletable(token) =>
+              val word = input.substring(start, end)
+              val wordCursor = cursor - start
+              parsedLine(word, wordCursor)
+            case _ =>
+              defaultParsedLine
+          }
+
+        case _ =>
+          incomplete()
+      }
+    }
+  }
+}

--- a/core/src/main/scala/replpp/JLineTerminal.scala
+++ b/core/src/main/scala/replpp/JLineTerminal.scala
@@ -82,7 +82,7 @@ class JLineTerminal extends java.io.Closeable {
   /** Provide syntax highlighting */
   private class Highlighter(using Context) extends reader.Highlighter {
     def highlight(reader: LineReader, buffer: String): AttributedString = {
-      val highlighted = SyntaxHighlighting.highlight(buffer)
+      val highlighted = replpp.SyntaxHighlighting.highlight(buffer)
       AttributedString.fromAnsi(highlighted)
     }
     def setErrorPattern(errorPattern: java.util.regex.Pattern): Unit = {}

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -35,7 +35,7 @@ class ReplDriver(args: Array[String],
     * Main difference to the 'original': different greeting, trap Ctrl-c
    */
   override def runUntilQuit(using initialState: State = initialState)(): State = {
-    val terminal = new JLineTerminal {
+    val terminal = new replpp.JLineTerminal {
       override protected def promptStr = prompt
     }
     greeting.foreach(out.println)
@@ -69,7 +69,7 @@ class ReplDriver(args: Array[String],
     * If the input contains a using file directive (e.g. `//> using file abc.sc`), then we interpret everything up
     * until the directive, then interpret the directive (i.e. import that file) and continue with the remainder of
     * our input. That way, we import the file in-place, while preserving line numbers for user feedback.  */
-  private def readLine(terminal: JLineTerminal, state: State): IterableOnce[String] = {
+  private def readLine(terminal: replpp.JLineTerminal, state: State): IterableOnce[String] = {
     given Context = state.context
     val completer: Completer = { (_, line, candidates) =>
       val comps = completions(line.cursor, line.line, state)

--- a/core/src/main/scala/replpp/SyntaxHighlighting.scala
+++ b/core/src/main/scala/replpp/SyntaxHighlighting.scala
@@ -28,9 +28,8 @@ object SyntaxHighlighting {
   val CommentColor: String    = Console.BLUE
   val KeywordColor: String    = Console.YELLOW
   val ValDefColor: String     = Console.CYAN
-  val LiteralColor: String    = Console.RED
-  val StringColor: String     = Console.GREEN
-  val TypeColor: String       = Console.MAGENTA
+  val LiteralColor: String    = Console.GREEN
+  val TypeColor: String       = Console.GREEN
   val AnnotationColor: String = Console.MAGENTA
 
   def highlight(in: String)(using Context): String = {

--- a/core/src/main/scala/replpp/SyntaxHighlighting.scala
+++ b/core/src/main/scala/replpp/SyntaxHighlighting.scala
@@ -1,0 +1,151 @@
+package replpp
+
+import scala.language.unsafeNulls
+
+import dotty.tools.dotc.CompilationUnit
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.StdNames._
+import dotty.tools.dotc.parsing.Parsers.Parser
+import dotty.tools.dotc.parsing.Scanners.Scanner
+import dotty.tools.dotc.parsing.Tokens._
+import dotty.tools.dotc.reporting.Reporter
+import dotty.tools.dotc.util.Spans.Span
+import dotty.tools.dotc.util.SourceFile
+
+import java.util.Arrays
+
+/** Based on https://github.com/lampepfl/dotty/blob/3.3.0-RC6/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala * and adapted for our needs
+  *
+  * This object provides functions for syntax highlighting in the REPL */
+object SyntaxHighlighting {
+
+  /** if true, log erroneous positions being highlighted */
+  private inline val debug = true
+
+  // Keep in sync with SyntaxHighlightingTests
+  val NoColor: String         = Console.RESET
+  val CommentColor: String    = Console.BLUE
+  val KeywordColor: String    = Console.YELLOW
+  val ValDefColor: String     = Console.CYAN
+  val LiteralColor: String    = Console.RED
+  val StringColor: String     = Console.GREEN
+  val TypeColor: String       = Console.MAGENTA
+  val AnnotationColor: String = Console.MAGENTA
+
+  def highlight(in: String)(using Context): String = {
+    def freshCtx = ctx.fresh.setReporter(Reporter.NoReporter)
+    if (in.isEmpty || ctx.settings.color.value == "never") in
+    else {
+      val source = SourceFile.virtual("<highlighting>", in)
+
+      given Context = freshCtx
+        .setCompilationUnit(CompilationUnit(source, mustExist = false)(using freshCtx))
+
+      val colorAt = Array.fill(in.length)(NoColor)
+
+      def highlightRange(from: Int, to: Int, color: String) =
+        Arrays.fill(colorAt.asInstanceOf[Array[AnyRef]], from, to, color)
+
+      def highlightPosition(span: Span, color: String) = if (span.exists)
+        if (span.start < 0 || span.end > in.length) {
+          if (debug)
+            println(s"Trying to highlight erroneous position $span. Input size: ${in.length}")
+        }
+        else
+          highlightRange(span.start, span.end, color)
+
+      val scanner = new Scanner(source)
+      while (scanner.token != EOF) {
+        val start = scanner.offset
+        val token = scanner.token
+        val name = scanner.name
+        val isSoftModifier = scanner.isSoftModifierInModifierPosition
+        scanner.nextToken()
+        val end = scanner.lastOffset
+
+        // Branch order is important. For example,
+        // `true` is at the same time a keyword and a literal
+        token match {
+          case _ if literalTokens.contains(token) =>
+            highlightRange(start, end, LiteralColor)
+
+          case STRINGPART =>
+            // String interpolation parts include `$` but
+            // we don't highlight it, hence the `-1`
+            highlightRange(start, end - 1, LiteralColor)
+
+          case _ if alphaKeywords.contains(token) || isSoftModifier =>
+            highlightRange(start, end, KeywordColor)
+
+          case IDENTIFIER if name == nme.??? =>
+            highlightRange(start, end, Console.RED_B)
+
+          case _ =>
+        }
+      }
+
+      for (span <- scanner.commentSpans)
+        highlightPosition(span, CommentColor)
+
+      object TreeHighlighter extends untpd.UntypedTreeTraverser {
+        import untpd._
+
+        def ignored(tree: NameTree) = {
+          val name = tree.name.toTermName
+          // trees named <error> and <init> have weird positions
+          name == nme.ERROR || name == nme.CONSTRUCTOR
+        }
+
+        def highlightAnnotations(tree: MemberDef): Unit = {
+          // TODO reimplement
+//          for (annotation <- tree.rawMods.annotations)
+//            highlightPosition(annotation.span, AnnotationColor)
+        }
+
+        def highlight(trees: List[Tree])(using Context): Unit =
+          trees.foreach(traverse)
+
+        def traverse(tree: Tree)(using Context): Unit = {
+          tree match {
+            case tree: NameTree if ignored(tree) =>
+              ()
+            case tree: ValOrDefDef =>
+              highlightAnnotations(tree)
+              highlightPosition(tree.nameSpan, ValDefColor)
+              highlightPosition(tree.endSpan, ValDefColor)
+            case tree: MemberDef /* ModuleDef | TypeDef */ =>
+              highlightAnnotations(tree)
+              highlightPosition(tree.nameSpan, TypeColor)
+              highlightPosition(tree.endSpan, TypeColor)
+            case tree: Ident if tree.isType =>
+              highlightPosition(tree.span, TypeColor)
+            case _: TypeTree =>
+              highlightPosition(tree.span, TypeColor)
+            case _ =>
+          }
+          traverseChildren(tree)
+        }
+      }
+
+      val parser = new Parser(source)
+      val trees = parser.blockStatSeq()
+      TreeHighlighter.highlight(trees)
+
+      val highlighted = new StringBuilder()
+
+      for (idx <- colorAt.indices) {
+        val prev = if (idx == 0) NoColor else colorAt(idx - 1)
+        val curr = colorAt(idx)
+        if (curr != prev)
+          highlighted.append(curr)
+        highlighted.append(in(idx))
+      }
+
+      if (colorAt.last != NoColor)
+        highlighted.append(NoColor)
+
+      highlighted.toString
+    }
+  }
+}


### PR DESCRIPTION
import and patch existing dotty SyntaxHighlighter to make use of the existing parser, but use the nicer ammonite color pallette

n.b. we can't just use pprinter here because the input is just a string. Ammonite ships it's on fastparse-based parser, but since dotty already has it's own parser, we might as well keep that and just adapt the colors

before:
![image](https://github.com/mpollmeier/scala-repl-pp/assets/506752/4addc1a0-108f-4b4c-afb8-34a1e8b736b7)

after:
![image](https://github.com/mpollmeier/scala-repl-pp/assets/506752/7a836e2a-84ef-464f-ae25-97b7a1e9ca0d)
