### PR TITLE
color highlight the identifier part of the output

### DIFF
--- a/core/src/main/scala/replpp/Rendering.scala
+++ b/core/src/main/scala/replpp/Rendering.scala
@@ -127,7 +127,7 @@ private[replpp] class Rendering(maxHeight: Option[Int],
 
   /** Render value definition result */
   def renderVal(d: Denotation)(using Context): Either[ReflectiveOperationException, Option[Diagnostic]] =
-    val dcl = d.symbol.showUser
+    val dcl = SyntaxHighlighting.highlight(d.symbol.showUser)
     def msg(s: String) = infoDiagnostic(s, d)
     try
       Right(


### PR DESCRIPTION
e.g. `val res0: In…t = 23`

before:
![image](https://github.com/mpollmeier/scala-repl-pp/assets/506752/3ca7dc8b-8279-465c-882d-b2a096f8d1c5)

with this:
![image](https://github.com/mpollmeier/scala-repl-pp/assets/506752/5bcc8039-013e-4787-b461-c4f6c0263f6c)
