### PR TITLE
pretty printing for all Operator usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,32 @@ scala> Seq("a", "b", "c") #| "cat"
 scala> Seq("a", "b", "c") #|^ "less"
 ```
 
-The above operators are supported for `String`, `IterableOnce` and `java.lang.Iterable`. 
+All operators use the same pretty-printing that's used within the REPL, i.e. you get structured rendering including product labels etc. 
+```scala
+scala> case class PrettyPrintable(s: String, i: Int)
+scala> PrettyPrintable("two", 2) #> "out.txt"
+// out.txt now contains `PrettyPrintable(s = "two", i = 2)`
+```
+
+The operators have a special handling for two common use cases that are applied at the root level of the object you hand them: list- or iterator-type objects are unwrapped and their elements are rendered in separate lines, and Strings are rendered without the surrounding `""`. Examples:
+```scala
+scala> "a string" #> "out.txt"
+// rendered as `a string` without quotes
+
+scala> Seq("one", "two") #> "out.txt"
+// rendered as two lines without quotes:
+// one
+// two
+
+scala> Seq("one", Seq("two"), Seq("three", 4), 5) #> "out.txt"
+// top-level list-types are unwrapped
+// resulting top-level strings are rendered without quotes:
+// one
+// List("two")
+// List("three", 4)
+// 5
+```
+
 All operators are prefixed with `#` in order to avoid naming clashes with more basic operators like `>` for greater-than-comparisons. This naming convention is inspired by scala.sys.process.
 
 ### Add dependencies with maven coordinates

--- a/core/src/main/scala/replpp/Operators.scala
+++ b/core/src/main/scala/replpp/Operators.scala
@@ -1,33 +1,35 @@
 package replpp
 
+import replpp.shaded.os
 import replpp.shaded.os.{ProcessInput, ProcessOutput, SubProcess}
 
-import java.io.{BufferedReader, ByteArrayOutputStream, FileWriter, InputStreamReader, PipedInputStream, PipedOutputStream, PrintStream}
+import java.io.FileWriter
 import java.lang.ProcessBuilder.Redirect
 import java.lang.System.lineSeparator
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
-import replpp.shaded.os
-import scala.jdk.CollectionConverters.IterableHasAsScala
-import scala.sys.process.Process
-import scala.util.{Failure, Success, Try, Using}
+import java.nio.file.{Path, Paths}
+import scala.jdk.CollectionConverters.*
+import scala.util.{Try, Using}
 
 /**
-  * Operators to redirect output to files or pipe them into external commands / processes,
-  * inspired by unix shell redirection and pipe operators: `>`, `>>` and `|`.
-  * Naming convention: similar to scala.sys.process we prefix all operators with `#`
-  * to avoid naming clashes with more basic operators like `>` for greater-than-comparisons.
-  * */
+ * Operators to redirect output to files or pipe them into external commands / processes,
+ * inspired by unix shell redirection and pipe operators: `>`, `>>` and `|`.
+ * Naming convention: similar to scala.sys.process we prefix all operators with `#`
+ * to avoid naming clashes with more basic operators like `>` for greater-than-comparisons.
+ *
+ * They are declared as extension types for `Any` and pretty-print the results using our `PPrinter`.
+ * List types (IterableOnce, java.lang.Iterable, Array, ...) are being unwrapped (only at the root level).
+ * */
 object Operators {
 
   /** output from an external command, e.g. when using `#|` */
   case class ProcessResults(stdout: String, stderr: String)
 
-  extension (value: String) {
+  extension (value: Any) {
 
     /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
     def #>(outFile: Path): Unit =
-      writeToFile(outFile, append = false)
+      writeToFile(valueAsString, outFile, append = false)
 
     /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
     def #>(outFileName: String): Unit =
@@ -35,65 +37,14 @@ object Operators {
 
     /** Redirect output into file, appending to that file - similar to `>>` redirection in unix. */
     def #>>(outFile: Path): Unit =
-      writeToFile(outFile, append = true)
+      writeToFile(valueAsString, outFile, append = true)
 
     /** Redirect output into file, appending to that file - similar to `>>` redirection in unix. */
     def #>>(outFileName: String): Unit =
       #>>(Paths.get(outFileName))
 
     /**
-     * Pipe output into an external process, i.e. pass the value into the command's InputStream.
-     * Returns a concatenation of the stdout and stderr of the external command.
-     * Executing an external command may fail, and this will throw an exception in that case.
-     * see `#|^` for a variant that inherits IO (e.g. for `less`)
-     */
-    def #|(command: String): String = {
-      val ProcessResults(stdout, stderr) = pipeToCommand(value, command, inheritIO = false).get
-      Seq(stdout, stderr).filter(_.nonEmpty).mkString(lineSeparator)
-    }
-
-    /**
-     * Pipe output into an external process, i.e. pass the value into the command's InputStream.
-     * Executing an external command may fail, and this will throw an exception in that case.
-     * This is a variant of `#|` which inherits IO (e.g. for `less`) - therefor it doesn't capture stdout/stderr. */
-    def #|^(command: String): Unit =
-      pipeToCommand(value, command, inheritIO = true).get
-
-    private def writeToFile(outFile: Path, append: Boolean): Unit = {
-      Using.resource(new FileWriter(outFile.toFile, append)) { fw =>
-        fw.write(value)
-        /* The convention on UNIX-like systems is that text files are supposed to end with a new-line.
-         * This is mostly a side-effect of the fact that UNIX tools must end their output with a newline if they
-         * don't want to mess up the prompt of the shell. And then piping the output of these tools to a file
-         * means these files always end with a newline. And so appending on the shell also just needs to do
-         * open(.., O_APPEND) and the appended output will automatically start in a new line.
-         */
-        fw.write(lineSeparator)
-      }
-    }
-  }
-
-  extension (iter: IterableOnce[_]) {
-    private def valueAsString: String = iter.iterator.mkString(lineSeparator)
-
-    /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
-    def #>(outFile: Path): Unit =
-      valueAsString #> outFile
-
-    /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
-    def #>(outFileName: String): Unit =
-      valueAsString #> outFileName
-
-    /** Redirect output into file, appending to that file - similar to `>>` redirection in unix. */
-    def #>>(outFile: Path): Unit =
-      valueAsString #>> outFile
-
-    /** Redirect output into file, appending to that file - similar to `>>` redirection in unix. */
-    def #>>(outFileName: String): Unit =
-      valueAsString #>> outFileName
-
-    /**
-     * Pipe output into an external process, i.e. pass the value into the command's InputStream.
+     * Pipe output into an external process, i.e. pass the valueAsString into the command's InputStream.
      * Returns a concatenation of the stdout and stderr of the external command.
      * Executing an external command may fail, and this will throw an exception in that case.
      * see `#|^` for a variant that inherits IO (e.g. for `less`)
@@ -104,47 +55,36 @@ object Operators {
     }
 
     /**
-     * Pipe output into an external process, i.e. pass the value into the command's InputStream.
+     * Pipe output into an external process, i.e. pass the valueAsString into the command's InputStream.
      * Executing an external command may fail, and this will throw an exception in that case.
      * This is a variant of `#|` which inherits IO (e.g. for `less`) - therefor it doesn't capture stdout/stderr. */
     def #|^(command: String): Unit =
       pipeToCommand(valueAsString, command, inheritIO = true).get
 
-  }
 
-  extension (iter: java.lang.Iterable[_]) {
-
-    /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
-    def #>(outFile: Path): Unit =
-      iter.asScala #> outFile
-
-    /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
-    def #>(outFileName: String): Unit =
-      iter.asScala #> outFileName
-
-    /** Redirect output into file, appending to that file - similar to `>>` redirection in unix. */
-    def #>>(outFile: Path): Unit =
-      iter.asScala #>> outFile
-
-    /** Redirect output into file, appending to that file - similar to `>>` redirection in unix. */
-    def #>>(outFileName: String): Unit =
-      iter.asScala #>> outFileName
+    private def valueAsString: String = asString(value)
 
     /**
-     * Pipe output into an external process, i.e. pass the value into the command's InputStream.
-     * Returns a concatenation of the stdout and stderr of the external command.
-     * Executing an external command may fail, and this will throw an exception in that case.
-     * see `#|^` for a variant that inherits IO (e.g. for `less`)
+     * If `value` is a list-type: unwrap it (only at the root level).
+     * Then, pretty-print the results using our `PPrinter`.
+     * This is to ensure we get the same output as we would get on the REPL (apart from the list-unwrapping).
      */
-    def #|(command: String): String =
-      iter.asScala #| command
-
-    /**
-     * Pipe output into an external process, i.e. pass the value into the command's InputStream.
-     * Executing an external command may fail, and this will throw an exception in that case.
-     * This is a variant of `#|` which inherits IO (e.g. for `less`) - therefor it doesn't capture stdout/stderr. */
-    def #|^(command: String): Unit =
-      iter.asScala #|^ command
+    private def asString(obj: Any): String = {
+      // TODO enable coloring by default, but allow to disable, e.g. by having an implicit import in scope
+      obj match {
+        case string: String => string
+        case iter: IterableOnce[_] =>
+          iter.iterator.map(asString).mkString(lineSeparator)
+        case iter: java.lang.Iterable[_] =>
+          asString(iter.asScala)
+        case iter: java.util.Iterator[_] =>
+          asString(iter.asScala)
+        case array: Array[_] =>
+          asString(array.toSeq)
+        case other =>
+          PPrinter(other, nocolors = true)
+      }
+    }
   }
 
   /**
@@ -200,6 +140,19 @@ object Operators {
         stringBuilder.addAll(lineSeparator)
       }
       stringBuilder.addAll(s)
+    }
+  }
+
+  private def writeToFile(value: String, outFile: Path, append: Boolean): Unit = {
+    Using.resource(new FileWriter(outFile.toFile, append)) { fw =>
+      fw.write(value)
+      /* The convention on UNIX-like systems is that text files are supposed to end with a new-line.
+       * This is mostly a side-effect of the fact that UNIX tools must end their output with a newline if they
+       * don't want to mess up the prompt of the shell. And then piping the output of these tools to a file
+       * means these files always end with a newline. And so appending on the shell also just needs to do
+       * open(.., O_APPEND) and the appended output will automatically start in a new line.
+       */
+      fw.write(lineSeparator)
     }
   }
 

--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -8,7 +8,7 @@ object PPrinter {
   private var maxHeight: Int = Int.MaxValue
   private var nocolors: Boolean = false
 
-  def apply(objectToRender: Object, maxHeight: Int = Int.MaxValue, nocolors: Boolean = false): String = {
+  def apply(objectToRender: Any, maxHeight: Int = Int.MaxValue, nocolors: Boolean = false): String = {
     val _pprinter = this.synchronized {
       // initialise on first use and whenever the maxHeight setting changed
       if (pprinter == null || this.maxHeight != maxHeight || this.nocolors != nocolors) {

--- a/out.txt
+++ b/out.txt
@@ -1,0 +1,2 @@
+List("one", "two")
+three

--- a/out.txt
+++ b/out.txt
@@ -1,2 +1,0 @@
-List("one", "two")
-three


### PR DESCRIPTION
* motivation: similar output as on repl
* list types are being unwrapped, but only at root level
* strings are being rendered without quotes, but only at top level
* both of the above are to support common use cases for exporting