### PR TITLE
colors: control via given (implicit) instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,12 @@ See [ScriptRunnerTest](core/src/test/scala/replpp/scripting/ScriptRunnerTest.sca
 test-simple.sc
 ```scala
 println("Hello!")
+"i was here" #> "out.txt"
 ```
 
 ```bash
 ./scala-repl-pp --script test-simple.sc
+cat out.txt # prints 'i was here'
 ```
 
 ### Predef file(s) used in script

--- a/core/src/main/scala/replpp/Config.scala
+++ b/core/src/main/scala/replpp/Config.scala
@@ -1,5 +1,7 @@
 package replpp
 
+import replpp.Colors.{BlackWhite, Default}
+
 import java.nio.file.Path
 
 case class Config(
@@ -27,6 +29,10 @@ case class Config(
   serverAuthUsername: Option[String] = None,
   serverAuthPassword: Option[String] = None,
 ) {
+  implicit val colors: Colors =
+    if (nocolors) Colors.BlackWhite
+    else Colors.Default
+
   /** inverse of `Config.parse` */
   lazy val asJavaArgs: Seq[String] = {
     val args = Seq.newBuilder[String]

--- a/core/src/main/scala/replpp/DottyReplDriver.scala
+++ b/core/src/main/scala/replpp/DottyReplDriver.scala
@@ -46,8 +46,7 @@ import scala.util.Using
 class DottyReplDriver(settings: Array[String],
                       out: PrintStream,
                       maxHeight: Option[Int],
-                      nocolors: Boolean,
-                      classLoader: Option[ClassLoader]) extends Driver:
+                      classLoader: Option[ClassLoader])(using Colors) extends Driver:
 
   /** Overridden to `false` in order to not have to give sources on the
    *  commandline
@@ -90,7 +89,7 @@ class DottyReplDriver(settings: Array[String],
       rootCtx = rootCtx.fresh
         .setSetting(rootCtx.settings.outputDir, new VirtualDirectory("<REPL compilation output>"))
     compiler = new ReplCompiler
-    rendering = new Rendering(maxHeight, nocolors, classLoader)
+    rendering = new Rendering(maxHeight, classLoader)
   }
 
   private var rootCtx: Context = _

--- a/core/src/main/scala/replpp/InteractiveShell.scala
+++ b/core/src/main/scala/replpp/InteractiveShell.scala
@@ -12,13 +12,13 @@ object InteractiveShell {
 
     val predefCode = allPredefCode(config)
     val compilerArgs = replpp.compilerArgs(config)
+    import config.colors
     val replDriver = new ReplDriver(
       compilerArgs,
       onExitCode = config.onExitCode,
       greeting = Option(config.greeting),
       prompt = config.prompt.getOrElse("scala"),
-      maxHeight = config.maxHeight,
-      nocolors = config.nocolors
+      maxHeight = config.maxHeight
     )
 
     val initialState: State = replDriver.initialState

--- a/core/src/main/scala/replpp/Operators.scala
+++ b/core/src/main/scala/replpp/Operators.scala
@@ -25,7 +25,7 @@ object Operators {
   /** output from an external command, e.g. when using `#|` */
   case class ProcessResults(stdout: String, stderr: String)
 
-  extension (value: Any) {
+  extension (value: Any)(using Colors) {
 
     /** Redirect output into file, overriding that file - similar to `>` redirection in unix. */
     def #>(outFile: Path): Unit =
@@ -89,10 +89,14 @@ object Operators {
      * Pretty-print the results using our `PPrinter`. Special handling for top level strings: render without quotes
      */
     private def render(obj: Any): String = {
-      // TODO enable coloring by default, but allow to disable, e.g. by having an implicit import in scope
       obj match {
-        case string: String => string
-        case other => PPrinter(other, nocolors = true)
+        case string: String =>
+          string
+        case other =>
+          PPrinter(
+            other,
+            nocolors = summon[Colors] == Colors.BlackWhite
+          )
       }
     }
   }

--- a/core/src/main/scala/replpp/Rendering.scala
+++ b/core/src/main/scala/replpp/Rendering.scala
@@ -23,9 +23,7 @@ import scala.util.control.NonFatal
  *       `ReplDriver#resetToInitial` is called, the accompanying instance of
  *       `Rendering` is no longer valid.
  */
-private[replpp] class Rendering(maxHeight: Option[Int],
-                                nocolors: Boolean,
-                                parentClassLoader: Option[ClassLoader] = None):
+private[replpp] class Rendering(maxHeight: Option[Int], parentClassLoader: Option[ClassLoader] = None)(using colors: Colors):
 
   import Rendering._
 
@@ -65,6 +63,11 @@ private[replpp] class Rendering(maxHeight: Option[Int],
           **/
         val pprinter = Class.forName("replpp.PPrinter", true, myClassLoader)
         val renderingMethod = pprinter.getMethod("apply", classOf[Object], classOf[Int], classOf[Boolean])
+        val nocolors = colors match {
+          case Colors.BlackWhite => true
+          case Colors.Default => false
+        }
+
         (objectToRender: Object, maxElements: Int, maxCharacters: Int) => {
           renderingMethod.invoke(null, objectToRender, maxHeight.getOrElse(Int.MaxValue), nocolors).asInstanceOf[String]
         }

--- a/core/src/main/scala/replpp/ReplDriver.scala
+++ b/core/src/main/scala/replpp/ReplDriver.scala
@@ -1,24 +1,12 @@
 package replpp
 
-import dotty.tools.MainGenericCompiler.classpathSeparator
-import dotty.tools.dotc.Run
-import dotty.tools.dotc.ast.{Positioned, tpd, untpd}
-import dotty.tools.dotc.classpath.{AggregateClassPath, ClassPathFactory}
-import dotty.tools.dotc.config.{Feature, JavaPlatform, Platform}
-import dotty.tools.dotc.core.Comments.{ContextDoc, ContextDocstrings}
-import dotty.tools.dotc.core.Contexts.{Context, ContextBase, ContextState, FreshContext, ctx, explore}
-import dotty.tools.dotc.core.{Contexts, MacroClassLoader, Mode, TyperState}
-import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation}
+import dotty.tools.dotc.core.Contexts
+import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.repl.*
 import org.jline.reader.*
 
 import java.io.PrintStream
-import java.lang.System.lineSeparator
-import java.net.URL
-import java.nio.file.Path
-import javax.naming.InitialContext
 import scala.annotation.tailrec
-import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -28,8 +16,8 @@ class ReplDriver(args: Array[String],
                  greeting: Option[String],
                  prompt: String,
                  maxHeight: Option[Int] = None,
-                 nocolors: Boolean = false,
-                 classLoader: Option[ClassLoader] = None) extends ReplDriverBase(args, out, maxHeight, nocolors, classLoader) {
+                 classLoader: Option[ClassLoader] = None)(using Colors)
+  extends ReplDriverBase(args, out, maxHeight, classLoader) {
 
   /** Run REPL with `state` until `:quit` command found
     * Main difference to the 'original': different greeting, trap Ctrl-c

--- a/core/src/main/scala/replpp/ReplDriverBase.scala
+++ b/core/src/main/scala/replpp/ReplDriverBase.scala
@@ -26,9 +26,8 @@ import scala.util.{Failure, Success, Try}
 abstract class ReplDriverBase(args: Array[String],
                               out: PrintStream,
                               maxHeight: Option[Int],
-                              nocolors: Boolean,
-                              classLoader: Option[ClassLoader])
-  extends DottyReplDriver(args, out, maxHeight, nocolors, classLoader) {
+                              classLoader: Option[ClassLoader])(using Colors)
+  extends DottyReplDriver(args, out, maxHeight, classLoader) {
 
   protected def interpretInput(lines: IterableOnce[String], state: State, currentFile: Path): State = {
     val parsedLines = Seq.newBuilder[String]

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -10,9 +10,7 @@ import scala.io.Source
 import scala.util.Using
 
 package object replpp {
-  enum Colors {
-    case BlackWhite, Default
-  }
+  enum Colors { case BlackWhite, Default }
 
   /* ":" on unix */
   val pathSeparator = java.io.File.pathSeparator
@@ -27,8 +25,17 @@ package object replpp {
 
   lazy val globalPredefFile = home.resolve(".scala-repl-pp.sc")
   lazy val globalPredefFileMaybe = Option(globalPredefFile).filter(Files.exists(_))
-  val DefaultPredefLines = Seq("import replpp.Operators.*")
-  lazy val DefaultPredef = DefaultPredefLines.mkString(lineSeparator)
+  private[replpp] def DefaultPredefLines(using colors: Colors) = {
+    val colorsImport = colors match {
+      case Colors.BlackWhite => "replpp.Colors.BlackWhite"
+      case Colors.Default => "replpp.Colors.Default"
+    }
+    Seq(
+      "import replpp.Operators.*",
+      s"given replpp.Colors = $colorsImport"
+    )
+  }
+  private[replpp] def DefaultPredef(using Colors) = DefaultPredefLines.mkString(lineSeparator)
 
   /** verbose mode can either be enabled via the config, or the environment variable `SCALA_REPL_PP_VERBOSE=true` */
   def verboseEnabled(config: Config): Boolean = {
@@ -89,6 +96,7 @@ package object replpp {
   def allPredefLines(config: Config): Seq[String] = {
     val resultLines = Seq.newBuilder[String]
     val visited = mutable.Set.empty[Path]
+    import config.colors
 
     resultLines ++= DefaultPredefLines
 

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -10,6 +10,10 @@ import scala.io.Source
 import scala.util.Using
 
 package object replpp {
+  enum Colors {
+    case BlackWhite, Default
+  }
+
   /* ":" on unix */
   val pathSeparator = java.io.File.pathSeparator
 

--- a/core/src/test/scala/replpp/ConfigTests.scala
+++ b/core/src/test/scala/replpp/ConfigTests.scala
@@ -8,6 +8,12 @@ import java.nio.file.Paths
 class ConfigTests extends AnyWordSpec with Matchers {
   val apacheRepo = "https://repository.apache.org/content/groups/public"
   val sonatypeRepo = "https://oss.sonatype.org/content/repositories/public"
+  
+  "color modes" in {
+    Config().colors shouldBe Colors.Default
+    Config(nocolors = false).colors shouldBe Colors.Default
+    Config(nocolors = true).colors shouldBe Colors.BlackWhite
+  }
 
   "asJavaArgs (inverse of Config.parse) for ScriptingDriver" in {
     val config = Config(

--- a/core/src/test/scala/replpp/ConfigTests.scala
+++ b/core/src/test/scala/replpp/ConfigTests.scala
@@ -2,13 +2,14 @@ package replpp
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import replpp.Colors
 
 import java.nio.file.Paths
 
 class ConfigTests extends AnyWordSpec with Matchers {
   val apacheRepo = "https://repository.apache.org/content/groups/public"
   val sonatypeRepo = "https://oss.sonatype.org/content/repositories/public"
-  
+
   "color modes" in {
     Config().colors shouldBe Colors.Default
     Config(nocolors = false).colors shouldBe Colors.Default

--- a/core/src/test/scala/replpp/OperatorsTests.scala
+++ b/core/src/test/scala/replpp/OperatorsTests.scala
@@ -2,6 +2,7 @@ package replpp.util
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import replpp.Colors
 import replpp.Operators.*
 
 import scala.jdk.CollectionConverters.*
@@ -18,6 +19,7 @@ import System.lineSeparator
   ```
 */
 class OperatorsTests extends AnyWordSpec with Matchers {
+  given Colors = Colors.BlackWhite
 
   case class PrettyPrintable(s: String, i: Int)
 

--- a/core/src/test/scala/replpp/PredefTests.scala
+++ b/core/src/test/scala/replpp/PredefTests.scala
@@ -2,15 +2,30 @@ package replpp
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import replpp.Colors.{BlackWhite, Default}
 
 class PredefTests extends AnyWordSpec with Matchers {
+  given Colors = Default
+
+  "default content" in {
+    allPredefCode(Config()) shouldBe s"""
+         |import replpp.Operators.*
+         |given replpp.Colors = replpp.Colors.Default
+         |""".stripMargin.trim
+
+    allPredefCode(Config(nocolors = true)) shouldBe
+      s"""
+         |import replpp.Operators.*
+         |given replpp.Colors = replpp.Colors.BlackWhite
+         |""".stripMargin.trim
+  }
 
   "import predef files in given order" in {
     val predefFile1 = os.temp("val foo = 10").toNIO
     val predefFile2 = os.temp("val bar = foo * 2").toNIO
 
     allPredefCode(Config(
-      predefFiles = Seq(predefFile1, predefFile2),
+      predefFiles = Seq(predefFile1, predefFile2)
     )) shouldBe
       s"""$DefaultPredef
          |val foo = 10

--- a/server/src/main/scala/replpp/server/EmbeddedRepl.scala
+++ b/server/src/main/scala/replpp/server/EmbeddedRepl.scala
@@ -3,6 +3,7 @@ package replpp.server
 import dotty.tools.dotc.config.Printers.config
 import dotty.tools.repl.State
 import org.slf4j.{Logger, LoggerFactory}
+import replpp.Colors.BlackWhite
 import replpp.{Config, ReplDriverBase, pwd}
 
 import java.io.*
@@ -83,7 +84,7 @@ class EmbeddedRepl(predefLines: IterableOnce[String] = Seq.empty) {
 }
 
 class ReplDriver(args: Array[String], out: PrintStream, classLoader: Option[ClassLoader])
-  extends ReplDriverBase(args, out, maxHeight = None, nocolors = true, classLoader) {
+  extends ReplDriverBase(args, out, maxHeight = None, classLoader)(using BlackWhite) {
   def execute(inputLines: IterableOnce[String])(using state: State = initialState): State =
     interpretInput(inputLines, state, pwd)
 }


### PR DESCRIPTION
* also: use colored output by default in operators
* `--nocolors` disabled colors for everything, as before