### PR TITLE
coursier: invoke in subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,17 @@ Famously one of the most popular question on stackoverflow is about how to exit 
 :q
 ```
 
+When the REPL is waiting for input we capture `Ctrl-c` and don't exit. If there's currently a long-running execution that you really *might* want to cancel you can press `Ctrl-c` again immediately which will kill the entire repl:
+```
+scala> Thread.sleep(50000)
+// press Ctrl-c
+Captured interrupt signal `INT` - if you want to kill the REPL, press Ctrl-c again within three seconds
+
+// press Ctrl-c again will exit the repl
+$
+```
+Context: we'd prefer to cancel the long-running operation, but that's not so easy on the JVM.
+
 ## Scripting
 
 See [ScriptRunnerTest](core/src/test/scala/replpp/scripting/ScriptRunnerTest.scala) for a more complete and in-depth overview.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.michaelpollmeier/scala-repl-pp-all_3/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.michaelpollmeier/scala-repl-pp-all_3)
 
 ## scala-repl-pp
-Scala REPL PlusPlus: a better Scala 3 REPL. With many features inspired by ammonite and scala-cli while keeping complexity low by depending on (and not adding much on top of) the stock Scala 3 REPL. 
+Scala REPL PlusPlus: a better Scala 3 REPL. Wraps the stock Scala 3 REPL and adds many features inspired by ammonite and scala-cli. Keeps complexity low by using some (shaded) libraries from the [com.lihaoyi](https://github.com/com-lihaoyi/) stack, as well as [coursier](https://get-coursier.io/) (invoked in a subprocess).
 
-This is (also) a breeding ground for improvements to the regular scala REPL: we're forking parts of the REPL to later bring the changes back into the dotty codebase (ideally).
+This is (also) a breeding ground for improvements to the stock Scala REPL: we're forking parts of the REPL to later bring the changes back into the dotty codebase (ideally).
 
 Runs on JDK11+.
 

--- a/README.md
+++ b/README.md
@@ -469,3 +469,7 @@ If there's a compilation issue, the temporary script file will not be deleted an
 
 ### Why do we ship a shaded copy of other libraries and not use dependencies?
 Scala-REPL-PP includes some small libraries (e.g. most of the com-haoyili universe) that have been copied as-is, but then moved into the `replpp.shaded` namespace. We didn't include them as regular dependencies, because repl users may want to use a different version of them, which may be incompatible with the version the repl uses. Thankfully their license is very permissive - a big thanks to the original authors! The instructions of which versions were used and what we copied are in [import-instructions.md](shaded-libs/import-instructions.md).
+
+### Where's the cache located on disk?
+The cache? The caches you mean! :)
+There's `~/.cache/scala-repl-pp` for the repl itself. Since we use coursier (via a subprocess) there's also `~/.cache/coursier`. 

--- a/all/src/main/scala/replpp/all/Main.scala
+++ b/all/src/main/scala/replpp/all/Main.scala
@@ -2,17 +2,15 @@ package replpp.all
 
 import replpp.scripting.ScriptRunner
 import replpp.server.ReplServer
-import replpp.{Config, InteractiveShell}
+import replpp.Config
 
 object Main {
   def main(args: Array[String]): Unit = {
     val config = Config.parse(args)
 
-    if (config.server) {
+    if (config.server)
       ReplServer.startHttpServer(config)
-    } else if (config.scriptFile.isDefined)
-      ScriptRunner.main(args)
     else 
-      InteractiveShell.run(config)
+      replpp.Main.main(args)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val core = project.in(file("core"))
   .enablePlugins(JavaAppPackaging)
   .settings(
     name := "scala-repl-pp-core",
+    Compile/mainClass := Some("replpp.Main"),
     executableScriptName := "scala-repl-pp",
     libraryDependencies ++= Seq(
       "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,
@@ -51,6 +52,7 @@ lazy val all = project.in(file("all"))
   .enablePlugins(JavaAppPackaging)
   .settings(
     name := "scala-repl-pp-all",
+    Compile/mainClass := Some("replpp.all.Main"),
     libraryDependencies += "org.slf4j" % "slf4j-simple" % "2.0.7" % Optional,
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,9 @@ publish/skip := true
 ThisBuild / organization := "com.michaelpollmeier"
 ThisBuild / scalaVersion := "3.3.0"
 
-lazy val ScalaTestVersion = "3.2.15"
+lazy val Slf4jVersion = "2.0.7"
 lazy val ScalaCollectionCompatVersion = "2.11.0"
+lazy val ScalaTestVersion = "3.2.15"
 
 lazy val shadedLibs = project.in(file("shaded-libs"))
   .settings(
@@ -23,13 +24,10 @@ lazy val core = project.in(file("core"))
   .settings(
     name := "scala-repl-pp-core",
     libraryDependencies ++= Seq(
-      "org.scala-lang"   %% "scala3-compiler" % scalaVersion.value,
-      ("io.get-coursier" %% "coursier"  % "2.1.5").cross(CrossVersion.for3Use2_13)
-        .exclude("org.scala-lang.modules", "scala-xml_2.13")
-        .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
-      "org.scala-lang.modules" %% "scala-xml" % "2.1.0", // required for coursier
-    )
-)
+      "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,
+      "org.slf4j" % "slf4j-api" % Slf4jVersion,
+    ),
+  )
 
 lazy val server = project.in(file("server"))
   .dependsOn(core)
@@ -40,7 +38,7 @@ lazy val server = project.in(file("server"))
     fork := true, // important: otherwise we run into classloader issues
     libraryDependencies ++= Seq(
       "com.lihaoyi"   %% "cask"         % "0.8.3",
-      "org.slf4j"      % "slf4j-simple" % "2.0.7" % Optional,
+      "org.slf4j"      % "slf4j-simple" % Slf4jVersion % Optional,
       "com.lihaoyi"   %% "requests"     % "0.8.0" % Test,
       "org.scalatest" %% "scalatest"    % ScalaTestVersion % "it",
     )

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,10 @@ lazy val shadedLibs = project.in(file("shaded-libs"))
 
 lazy val core = project.in(file("core"))
   .dependsOn(shadedLibs)
+  .enablePlugins(JavaAppPackaging)
   .settings(
     name := "scala-repl-pp-core",
+    executableScriptName := "scala-repl-pp",
     libraryDependencies ++= Seq(
       "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,
       "org.slf4j" % "slf4j-api" % Slf4jVersion,

--- a/core/src/main/scala/replpp/Dependencies.scala
+++ b/core/src/main/scala/replpp/Dependencies.scala
@@ -1,23 +1,22 @@
 package replpp
 
-import java.io.File
+import replpp.shaded.os
+import replpp.util.Cache
+
 import java.net.URI
 import java.nio.file.{Path, Paths}
 import scala.util.{Failure, Success, Try}
-import replpp.util.Cache
-import replpp.shaded.os
-
-import sys.process.Process
 
 object Dependencies {
 
   private val CoursierJarDownloadUrl = new URI("https://github.com/coursier/launchers/raw/master/coursier")
 
   def resolve(coordinates: Seq[String], additionalRepositories: Seq[String] = Nil, verbose: Boolean = false): Try[Seq[Path]] = {
-    // TODO handle additionalRepositories: Seq[String] = Nil
-
     val coursierJarPath = Cache.getOrDownload("coursier.jar", CoursierJarDownloadUrl)
-    val command = Seq("java", "-jar", coursierJarPath.toAbsolutePath.toString, "fetch") ++ coordinates
+    val repositoryArgs = additionalRepositories.flatMap { repo =>
+      Seq("--repository", repo)
+    }
+    val command = Seq("java", "-jar", coursierJarPath.toAbsolutePath.toString, "fetch") ++ repositoryArgs ++ coordinates
     if (verbose) println(s"executing `${command.mkString(" ")}`")
 
     Try(os.proc(command).call()) match {
@@ -27,33 +26,5 @@ object Dependencies {
         Failure(new AssertionError(s"${getClass.getName}: error while invoking `${command.mkString(" ")}`", exception))
     }
   }
-
-//  private def parseRepositories(additionalRepositories: Seq[String]): Try[Seq[Repository]] = {
-//    ???
-//    Try {
-//      val parseResults = RepositoryParser.repositories(additionalRepositories)
-//      parseResults.either match {
-//        case Right(res) => res
-//        case Left(failures) =>
-//          throw new AssertionError(s"error while trying to parse given repository coordinates: ${failures.mkString(",")}")
-//      }
-//    }
-//  }
-
-//  private def parseDependencies(coordinates: Seq[String]): Try[Seq[Dependency]] =
-//    util.sequenceTry(coordinates.map(parseDependency))
-//
-//  private def parseDependency(coordinate: String): Try[Dependency] = {
-//    lazy val errorGeneric = s"error while trying to parse the following dependency coordinate: `$coordinate`"
-//    Try {
-//      DependencyParser.dependency(coordinate, defaultScalaVersion = "3") match {
-//        // I'd expect coursier to return a `Left(errorMsg)` here in all error scenarios, but it only does it in certain scenarios...
-//        case Left(error) => throw new AssertionError(s"$errorGeneric: $error")
-//        case Right(value) => value
-//      }
-//    }.recover {
-//      case error => throw new AssertionError(errorGeneric, error)
-//    }
-//  }
 
 }

--- a/core/src/main/scala/replpp/Dependencies.scala
+++ b/core/src/main/scala/replpp/Dependencies.scala
@@ -12,6 +12,14 @@ object Dependencies {
   private val CoursierJarDownloadUrl = new URI("https://github.com/coursier/launchers/raw/master/coursier")
 
   def resolve(coordinates: Seq[String], additionalRepositories: Seq[String] = Nil, verbose: Boolean = false): Try[Seq[Path]] = {
+    if (coordinates.isEmpty) {
+      Try(Seq.empty)
+    } else {
+      resolve0(coordinates, additionalRepositories, verbose)
+    }
+  }
+
+  private def resolve0(coordinates: Seq[String], additionalRepositories: Seq[String], verbose: Boolean): Try[Seq[Path]] = {
     val coursierJarPath = Cache.getOrDownload("coursier.jar", CoursierJarDownloadUrl)
     val repositoryArgs = additionalRepositories.flatMap { repo =>
       Seq("--repository", repo)

--- a/core/src/main/scala/replpp/Dependencies.scala
+++ b/core/src/main/scala/replpp/Dependencies.scala
@@ -1,59 +1,59 @@
 package replpp
 
-import coursier.Dependency
-import coursier.cache.FileCache
-import coursier.cache.loggers.RefreshLogger
-import coursier.core.Repository
-import coursier.parse.{DependencyParser, RepositoryParser}
-
 import java.io.File
-import java.nio.file.Path
+import java.net.URI
+import java.nio.file.{Path, Paths}
 import scala.util.{Failure, Success, Try}
+import replpp.util.Cache
+import replpp.shaded.os
+
+import sys.process.Process
 
 object Dependencies {
 
-  def resolve(coordinates: Seq[String], additionalRepositories: Seq[String] = Nil): Try[Seq[File]] = {
-    for {
-      repositories <- parseRepositories(additionalRepositories)
-      dependencies <- parseDependencies(coordinates)
-    } yield {
-      // the default cache throws away the credentials... see PlatformCacheCompanion.scala
-      val cache = FileCache().withLogger(RefreshLogger.create())
+  private val CoursierJarDownloadUrl = new URI("https://github.com/coursier/launchers/raw/master/coursier")
 
-      coursier.Fetch()
-        .withCache(cache)
-        .addRepositories(repositories: _*)
-        .addDependencies(dependencies: _*)
-        .run()
+  def resolve(coordinates: Seq[String], additionalRepositories: Seq[String] = Nil, verbose: Boolean = false): Try[Seq[Path]] = {
+    // TODO handle additionalRepositories: Seq[String] = Nil
+
+    val coursierJarPath = Cache.getOrDownload("coursier.jar", CoursierJarDownloadUrl)
+    val command = Seq("java", "-jar", coursierJarPath.toAbsolutePath.toString, "fetch") ++ coordinates
+    if (verbose) println(s"executing `${command.mkString(" ")}`")
+
+    Try(os.proc(command).call()) match {
+      case Success(commandResult) =>
+        Success(commandResult.out.text().split(System.lineSeparator()).map(Paths.get(_)))
+      case Failure(exception) =>
+        Failure(new AssertionError(s"${getClass.getName}: error while invoking `${command.mkString(" ")}`", exception))
     }
   }
 
-  private def parseRepositories(additionalRepositories: Seq[String]): Try[Seq[Repository]] = {
-    Try {
-      val parseResults = RepositoryParser.repositories(additionalRepositories)
-      parseResults.either match {
-        case Right(res) => res
-        case Left(failures) =>
-          throw new AssertionError(s"error while trying to parse given repository coordinates: ${failures.mkString(",")}")
-      }
-    }
-  }
+//  private def parseRepositories(additionalRepositories: Seq[String]): Try[Seq[Repository]] = {
+//    ???
+//    Try {
+//      val parseResults = RepositoryParser.repositories(additionalRepositories)
+//      parseResults.either match {
+//        case Right(res) => res
+//        case Left(failures) =>
+//          throw new AssertionError(s"error while trying to parse given repository coordinates: ${failures.mkString(",")}")
+//      }
+//    }
+//  }
 
-
-  private def parseDependencies(coordinates: Seq[String]): Try[Seq[Dependency]] =
-    util.sequenceTry(coordinates.map(parseDependency))
-
-  private def parseDependency(coordinate: String): Try[Dependency] = {
-    lazy val errorGeneric = s"error while trying to parse the following dependency coordinate: `$coordinate`"
-    Try {
-      DependencyParser.dependency(coordinate, defaultScalaVersion = "3") match {
-        // I'd expect coursier to return a `Left(errorMsg)` here in all error scenarios, but it only does it in certain scenarios...
-        case Left(error) => throw new AssertionError(s"$errorGeneric: $error")
-        case Right(value) => value
-      }
-    }.recover {
-      case error => throw new AssertionError(errorGeneric, error)
-    }
-  }
+//  private def parseDependencies(coordinates: Seq[String]): Try[Seq[Dependency]] =
+//    util.sequenceTry(coordinates.map(parseDependency))
+//
+//  private def parseDependency(coordinate: String): Try[Dependency] = {
+//    lazy val errorGeneric = s"error while trying to parse the following dependency coordinate: `$coordinate`"
+//    Try {
+//      DependencyParser.dependency(coordinate, defaultScalaVersion = "3") match {
+//        // I'd expect coursier to return a `Left(errorMsg)` here in all error scenarios, but it only does it in certain scenarios...
+//        case Left(error) => throw new AssertionError(s"$errorGeneric: $error")
+//        case Right(value) => value
+//      }
+//    }.recover {
+//      case error => throw new AssertionError(errorGeneric, error)
+//    }
+//  }
 
 }

--- a/core/src/main/scala/replpp/Dependencies.scala
+++ b/core/src/main/scala/replpp/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
 
     Try(os.proc(command).call()) match {
       case Success(commandResult) =>
-        Success(commandResult.out.text().split(System.lineSeparator()).map(Paths.get(_)))
+        Success(commandResult.out.text().split(System.lineSeparator()).map(Paths.get(_)).toIndexedSeq)
       case Failure(exception) =>
         Failure(new AssertionError(s"${getClass.getName}: error while invoking `${command.mkString(" ")}`", exception))
     }

--- a/core/src/main/scala/replpp/Main.scala
+++ b/core/src/main/scala/replpp/Main.scala
@@ -1,0 +1,18 @@
+package replpp
+
+import replpp.scripting.ScriptRunner
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val config = Config.parse(args)
+
+    if (config.server) {
+      System.err.println("please use `replpp.all.Main` main method to start the server")
+      System.exit(1)
+    } else if (config.scriptFile.isDefined) {
+      ScriptRunner.main(args)
+    } else {
+      InteractiveShell.run(config)
+    }
+  }
+}

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -68,7 +68,7 @@ package object replpp {
     System.getProperty("java.class.path").split(pathSeparator).foreach(entries.addOne)
 
     val fromDependencies = dependencyArtifacts(config)
-    fromDependencies.foreach(file => entries.addOne(file.getPath))
+    fromDependencies.foreach(file => entries.addOne(file.toString))
     if (fromDependencies.nonEmpty && !quiet) {
       println(s"resolved dependencies - adding ${fromDependencies.size} artifact(s) to classpath - to list them, enable verbose mode")
       if (verboseEnabled(config)) fromDependencies.foreach(println)
@@ -85,7 +85,7 @@ package object replpp {
     entries.result().distinct.sorted.mkString(pathSeparator, pathSeparator, pathSeparator)
   }
 
-  private def dependencyArtifacts(config: Config): Seq[File] = {
+  private def dependencyArtifacts(config: Config): Seq[Path] = {
     val scriptLines = config.scriptFile.map { path =>
        Using.resource(Source.fromFile(path.toFile))(_.getLines.toSeq)
     }.getOrElse(Seq.empty)
@@ -93,7 +93,7 @@ package object replpp {
 
     val resolvers = config.resolvers ++ UsingDirectives.findResolvers(allLines)
     val allDependencies = config.dependencies ++ UsingDirectives.findDeclaredDependencies(allLines)
-    Dependencies.resolve(allDependencies, resolvers).get
+    Dependencies.resolve(allDependencies, resolvers, verboseEnabled(config)).get
   }
   
   private def jarsFromClassLoaderRecursively(classLoader: ClassLoader): Seq[URL] = {

--- a/core/src/main/scala/replpp/util/Cache.scala
+++ b/core/src/main/scala/replpp/util/Cache.scala
@@ -9,7 +9,7 @@ import java.nio.file.{Files, Path}
 /** A simple cache for `cacheKey` -> `Path`, where `Path` is a single file */
 object Cache {
   lazy val Dir: Path = {
-    val dir = home.resolve(".scala-repl-pp/cache")
+    val dir = home.resolve(".cache/scala-repl-pp")
     if (Files.notExists(dir)) Files.createDirectories(dir)
     dir
   }

--- a/core/src/main/scala/replpp/util/Cache.scala
+++ b/core/src/main/scala/replpp/util/Cache.scala
@@ -2,7 +2,7 @@ package replpp.util
 
 import replpp.home
 
-import java.io.{FileOutputStream, InputStream}
+import java.io.InputStream
 import java.net.URI
 import java.nio.file.{Files, Path}
 
@@ -30,7 +30,9 @@ object Cache {
 
   /** similar to `getOrObtain`, but specifically for files that need to be downloaded */
   def getOrDownload(cacheKey: String, downloadUrl: URI): Path = {
-    ???
+    getOrObtain(cacheKey, obtain = () => {
+      downloadUrl.toURL.openStream()
+    })
   }
 
   /**

--- a/core/src/main/scala/replpp/util/Cache.scala
+++ b/core/src/main/scala/replpp/util/Cache.scala
@@ -1,0 +1,52 @@
+package replpp.util
+
+import replpp.home
+
+import java.io.{FileOutputStream, InputStream}
+import java.net.URI
+import java.nio.file.{Files, Path}
+
+/**
+ * A simple cache for `cacheKey` -> `Path`, where `Path` is a single file or directory
+ */
+object Cache {
+  lazy val Dir: Path = {
+    val dir = home.resolve(".scala-repl-pp/cache")
+    if (Files.notExists(dir)) Files.createDirectories(dir)
+    dir
+  }
+
+  def getOrObtain(cacheKey: String, obtain: () => InputStream): Path = {
+    val path = targetPath(cacheKey)
+    if (Files.exists(path)) {
+      path
+    } else {
+      val inputStream = obtain()
+      Files.copy(inputStream, path)
+      inputStream.close()
+      path
+    }
+  }
+
+  /** similar to `getOrObtain`, but specifically for files that need to be downloaded */
+  def getOrDownload(cacheKey: String, downloadUrl: URI): Path = {
+    ???
+  }
+
+  /**
+   * @return true if cache entry did actually exist
+   */
+  def remove(cacheKey: String): Boolean = {
+    val path = targetPath(cacheKey)
+    val entryExisted = Files.exists(path)
+
+    if (entryExisted)
+      deleteRecursively(path)
+
+    entryExisted
+  }
+
+  private def targetPath(cacheKey: String): Path =
+    Dir.resolve(cacheKey)
+
+}

--- a/core/src/main/scala/replpp/util/Cache.scala
+++ b/core/src/main/scala/replpp/util/Cache.scala
@@ -6,9 +6,7 @@ import java.io.InputStream
 import java.net.URI
 import java.nio.file.{Files, Path}
 
-/**
- * A simple cache for `cacheKey` -> `Path`, where `Path` is a single file or directory
- */
+/** A simple cache for `cacheKey` -> `Path`, where `Path` is a single file */
 object Cache {
   lazy val Dir: Path = {
     val dir = home.resolve(".scala-repl-pp/cache")

--- a/core/src/test/scala/replpp/DependenciesTests.scala
+++ b/core/src/test/scala/replpp/DependenciesTests.scala
@@ -1,12 +1,9 @@
 package replpp
 
-import coursier.cache.{CacheDefaults, FileCache}
-import coursier.credentials.Credentials
-import coursier.parse.DependencyParser
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.io.File
+import java.nio.file.Path
 
 class DependenciesTests extends AnyWordSpec with Matchers {
   val coursierCache = os.home / ".cache" / "coursier" / "v1"
@@ -15,7 +12,6 @@ class DependenciesTests extends AnyWordSpec with Matchers {
   "artifact resolution including transitive dependencies" should {
     "work for java artifacts" in {
       val jars = Dependencies.resolve(Seq("io.shiftleft:overflowdb-core:1.171")).get
-      val mvstoreJar = coursierCache / os.RelPath("https/repo1.maven.org/maven2/com/h2database/h2-mvstore/1.4.200/")
 
       ensureContains("overflowdb-core-1.171.jar", jars)
       ensureContains("h2-mvstore-1.4.200.jar", jars)
@@ -28,7 +24,7 @@ class DependenciesTests extends AnyWordSpec with Matchers {
       ensureContains("scala3-library_3-3.1.3.jar", jars)
     }
 
-    def ensureContains(fileName: String, jars: Seq[File]): Unit = {
+    def ensureContains(fileName: String, jars: Seq[Path]): Unit = {
       assert(jars.exists(_.toString.endsWith(fileName)), s"expected $fileName, but it's not in the results: $jars")
     }
   }
@@ -36,7 +32,7 @@ class DependenciesTests extends AnyWordSpec with Matchers {
   "return failure for invalid dependency coordinate" in {
     val parseResult = Dependencies.resolve(Seq("not-a-valid-maven-coordinate"))
     val errorMessage = parseResult.failed.get.getMessage
-    errorMessage should include("error while trying to parse the following dependency coordinate: `not-a-valid-maven-coordinate`")
+    errorMessage should include("fetch not-a-valid-maven-coordinate")
   }
 
   "return failure for invalid repository" in {

--- a/core/src/test/scala/replpp/DependenciesTests.scala
+++ b/core/src/test/scala/replpp/DependenciesTests.scala
@@ -41,7 +41,7 @@ class DependenciesTests extends AnyWordSpec with Matchers {
       Seq("not-a-valid-repository"),
     )
     val errorMessage = parseResult.failed.get.getMessage
-    errorMessage should include("error while trying to parse given repository coordinates")
+    errorMessage should include("not-a-valid-repository")
   }
 }
 

--- a/core/src/test/scala/replpp/util/CacheTests.scala
+++ b/core/src/test/scala/replpp/util/CacheTests.scala
@@ -1,0 +1,36 @@
+package replpp.util
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import replpp.Colors
+
+import java.io.FileInputStream
+import java.nio.file.Paths
+
+class CacheTests extends AnyWordSpec with Matchers {
+
+  "caches a file by it's key" in {
+    var obtainedFunctionInvocations = 0
+    val cacheKey = "test-cacheKey"
+
+    Cache.remove(cacheKey)
+    Cache.getOrObtain(
+      cacheKey,
+      obtain = () => {
+        obtainedFunctionInvocations += 1
+        new FileInputStream(ProjectRoot.relativise("README.md").toFile)
+      }
+    )
+    Cache.getOrObtain(
+      cacheKey,
+      obtain = () => {
+        obtainedFunctionInvocations += 1
+        new FileInputStream(ProjectRoot.relativise("README.md").toFile)
+      }
+    )
+
+    obtainedFunctionInvocations shouldBe 1
+    Cache.remove(cacheKey) shouldBe true
+  }
+
+}

--- a/core/src/test/scala/replpp/util/CacheTests.scala
+++ b/core/src/test/scala/replpp/util/CacheTests.scala
@@ -2,18 +2,18 @@ package replpp.util
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import replpp.Colors
 
 import java.io.FileInputStream
-import java.nio.file.Paths
+import java.net.URI
+import java.nio.file.Files
 
 class CacheTests extends AnyWordSpec with Matchers {
 
   "caches a file by it's key" in {
     var obtainedFunctionInvocations = 0
-    val cacheKey = "test-cacheKey"
-
+    val cacheKey = "test-cacheKey1"
     Cache.remove(cacheKey)
+    
     Cache.getOrObtain(
       cacheKey,
       obtain = () => {
@@ -21,7 +21,7 @@ class CacheTests extends AnyWordSpec with Matchers {
         new FileInputStream(ProjectRoot.relativise("README.md").toFile)
       }
     )
-    Cache.getOrObtain(
+    val cachedFile = Cache.getOrObtain(
       cacheKey,
       obtain = () => {
         obtainedFunctionInvocations += 1
@@ -30,6 +30,17 @@ class CacheTests extends AnyWordSpec with Matchers {
     )
 
     obtainedFunctionInvocations shouldBe 1
+    Files.size(cachedFile) should be > 1024L
+    Cache.remove(cacheKey) shouldBe true
+  }
+
+  "convenience function to download by URL" in {
+    val cacheKey = "test-cacheKey2"
+    Cache.remove(cacheKey)
+    
+    val cachedFile = Cache.getOrDownload(cacheKey, new URI("https://raw.githubusercontent.com/mpollmeier/scala-repl-pp/main/README.md"))
+
+    Files.size(cachedFile) should be > 1024L
     Cache.remove(cacheKey) shouldBe true
   }
 

--- a/scala-repl-pp
+++ b/scala-repl-pp
@@ -1,1 +1,1 @@
-all/target/universal/stage/bin/scala-repl-pp-all
+core/target/universal/stage/bin/scala-repl-pp

--- a/scala-repl-pp.bat
+++ b/scala-repl-pp.bat
@@ -1,1 +1,1 @@
-all/target/universal/stage/bin/scala-repl-pp-all.bat
+core/target/universal/stage/bin/scala-repl-pp.bat


### PR DESCRIPTION
* so that we don't have it in our classpath, and the user is free to use whatever version of coursier (or none) they want for their own needs. 
* also adds a cache (for the coursier jar)