### PR TITLE
classpath: deduplicate and choose highest version for each artifact

### DIFF
--- a/core/src/main/scala/replpp/Config.scala
+++ b/core/src/main/scala/replpp/Config.scala
@@ -71,7 +71,7 @@ object Config {
     val replppVersion = getClass.getPackage.getImplementationVersion
     val scalaVersion = scala.util.Properties.versionNumberString
     val javaVersion = sys.props("java.version")
-   s"Welcome to scala-repl-pp $replppVersion (Scala $scalaVersion, Java $javaVersion)"
+    s"Welcome to scala-repl-pp $replppVersion (Scala $scalaVersion, Java $javaVersion)"
   }
 
   def parse(args: Array[String]): Config = {

--- a/core/src/main/scala/replpp/JLineTerminal.scala
+++ b/core/src/main/scala/replpp/JLineTerminal.scala
@@ -64,7 +64,7 @@ class JLineTerminal extends java.io.Closeable {
    *  - Syntax highlighting
    *  - Auto-completions
    *
-   *  @throws EndOfFileException This exception is thrown when the user types Ctrl-D.
+   *  @throws org.jline.reader.EndOfFileException This exception is thrown when the user types Ctrl-D.
    */
   def readLine(
     completer: Completer // provide auto-completions

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -1,6 +1,7 @@
 import replpp.util.{ClasspathHelper, linesFromFile}
 
 import java.io.File
+import java.io.File.pathSeparator
 import java.lang.System.lineSeparator
 import java.net.URL
 import java.nio.file.{Files, Path, Paths}
@@ -11,9 +12,6 @@ import scala.util.Using
 
 package object replpp {
   enum Colors { case BlackWhite, Default }
-
-  /* ":" on unix */
-  val pathSeparator = java.io.File.pathSeparator
 
   val VerboseEnvVar    = "SCALA_REPL_PP_VERBOSE"
 
@@ -45,7 +43,7 @@ package object replpp {
 
   def compilerArgs(config: Config): Array[String] = {
     val compilerArgs = Array.newBuilder[String]
-    compilerArgs ++= Array("-classpath", ClasspathHelper.build(config))
+    compilerArgs ++= Array("-classpath", ClasspathHelper.create(config))
     compilerArgs += "-explain" // verbose scalac error messages
     compilerArgs += "-deprecation"
     if (config.nocolors) compilerArgs ++= Array("-color", "never")

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -1,4 +1,4 @@
-import replpp.util.linesFromFile
+import replpp.util.{ClasspathHelper, linesFromFile}
 
 import java.io.File
 import java.lang.System.lineSeparator
@@ -45,64 +45,12 @@ package object replpp {
 
   def compilerArgs(config: Config): Array[String] = {
     val compilerArgs = Array.newBuilder[String]
-    compilerArgs ++= Array("-classpath", classpath(config))
+    compilerArgs ++= Array("-classpath", ClasspathHelper.build(config))
     compilerArgs += "-explain" // verbose scalac error messages
     compilerArgs += "-deprecation"
     if (config.nocolors) compilerArgs ++= Array("-color", "never")
 
     compilerArgs.result()
-  }
-
-  /**
-   * Concatenates the classpath from multiple sources, each are required for different scenarios:
-   * - `java.class.path` system property
-   * - dependency artifacts as passed via (command-line) configuration
-   * - jars from current class loader (recursively)
-   *
-   * To have reproducable results, we order the classpath entries. This may interfere with the user's deliberate choice
-   * of order, but since we need to concatenate the classpath from different sources, the user can't really depend on
-   * the order anyway.
-   */
-  def classpath(config: Config, quiet: Boolean = false): String = {
-    val entries = Seq.newBuilder[String]
-    System.getProperty("java.class.path").split(pathSeparator).foreach(entries.addOne)
-
-    val fromDependencies = dependencyArtifacts(config)
-    fromDependencies.foreach(file => entries.addOne(file.toString))
-    if (fromDependencies.nonEmpty && !quiet) {
-      println(s"resolved dependencies - adding ${fromDependencies.size} artifact(s) to classpath - to list them, enable verbose mode")
-      if (verboseEnabled(config)) fromDependencies.foreach(println)
-    }
-
-    jarsFromClassLoaderRecursively(classOf[replpp.ReplDriver].getClassLoader)
-      .foreach(url => entries.addOne(url.getPath))
-
-    /** Important: we absolutely have to make sure this ends with a `pathSeparator`.
-     * Otherwise, the last entry is lost somewhere down the line. I'm still debugging where exactly, but it looks
-     * like somewhere in dotty. Will report upstream once I figured it out, but for now it doesn't harm to add a
-     * pathseparator at the end.
-     */
-    entries.result().distinct.sorted.mkString(pathSeparator, pathSeparator, pathSeparator)
-  }
-
-  private def dependencyArtifacts(config: Config): Seq[Path] = {
-    val scriptLines = config.scriptFile.map { path =>
-       Using.resource(Source.fromFile(path.toFile))(_.getLines.toSeq)
-    }.getOrElse(Seq.empty)
-    val allLines = allPredefLines(config) ++ scriptLines
-
-    val resolvers = config.resolvers ++ UsingDirectives.findResolvers(allLines)
-    val allDependencies = config.dependencies ++ UsingDirectives.findDeclaredDependencies(allLines)
-    Dependencies.resolve(allDependencies, resolvers, verboseEnabled(config)).get
-  }
-  
-  private def jarsFromClassLoaderRecursively(classLoader: ClassLoader): Seq[URL] = {
-    classLoader match {
-      case cl: java.net.URLClassLoader =>
-        jarsFromClassLoaderRecursively(cl.getParent) ++ cl.getURLs
-      case _ =>
-        Seq.empty
-    }
   }
 
   def allPredefCode(config: Config): String =

--- a/core/src/main/scala/replpp/scripting/ScriptRunner.scala
+++ b/core/src/main/scala/replpp/scripting/ScriptRunner.scala
@@ -1,6 +1,7 @@
 package replpp.scripting
 
 import replpp.Config
+import replpp.util.ClasspathHelper
 
 import scala.util.{Failure, Success, Try}
 import sys.process.Process
@@ -15,7 +16,7 @@ object ScriptRunner {
   val RemoteJvmDebugConfig = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"
 
   def exec(config: Config): Try[Unit] = {
-    val classpath = replpp.classpath(config, quiet = true)
+    val classpath = ClasspathHelper.build(config, quiet = true)
     val mainClass = "replpp.scripting.NonForkingScriptRunner"
     val args = {
       val builder = Seq.newBuilder[String]

--- a/core/src/main/scala/replpp/scripting/ScriptRunner.scala
+++ b/core/src/main/scala/replpp/scripting/ScriptRunner.scala
@@ -16,7 +16,7 @@ object ScriptRunner {
   val RemoteJvmDebugConfig = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"
 
   def exec(config: Config): Try[Unit] = {
-    val classpath = ClasspathHelper.build(config, quiet = true)
+    val classpath = ClasspathHelper.create(config, quiet = true)
     val mainClass = "replpp.scripting.NonForkingScriptRunner"
     val args = {
       val builder = Seq.newBuilder[String]

--- a/core/src/main/scala/replpp/scripting/ScriptingDriver.scala
+++ b/core/src/main/scala/replpp/scripting/ScriptingDriver.scala
@@ -4,10 +4,10 @@ import dotty.tools.dotc.Driver
 import dotty.tools.dotc.core.Contexts
 import dotty.tools.dotc.core.Contexts.{Context, ctx}
 import dotty.tools.io.{ClassPath, Directory, PlainDirectory}
-import replpp.pathSeparator
 import replpp.util.deleteRecursively
 import replpp.scripting.ScriptingDriver.*
 
+import java.io.File.pathSeparator
 import java.lang.reflect.{Method, Modifier}
 import java.net.URLClassLoader
 import java.nio.file.{Files, Path, Paths}

--- a/core/src/main/scala/replpp/util/Cache.scala
+++ b/core/src/main/scala/replpp/util/Cache.scala
@@ -16,13 +16,15 @@ object Cache {
 
   def getOrObtain(cacheKey: String, obtain: () => InputStream): Path = {
     val path = targetPath(cacheKey)
-    if (Files.exists(path)) {
-      path
-    } else {
-      val inputStream = obtain()
-      Files.copy(inputStream, path)
-      inputStream.close()
-      path
+    this.synchronized {
+      if (Files.exists(path)) {
+        path
+      } else {
+        val inputStream = obtain()
+        Files.copy(inputStream, path)
+        inputStream.close()
+        path
+      }
     }
   }
 

--- a/core/src/main/scala/replpp/util/ClasspathHelper.scala
+++ b/core/src/main/scala/replpp/util/ClasspathHelper.scala
@@ -1,0 +1,65 @@
+package replpp
+package util
+
+import replpp.Config
+
+import java.net.URL
+import java.nio.file.Path
+import scala.io.Source
+import scala.util.Using
+
+object ClasspathHelper {
+
+  /**
+   * Concatenates the classpath from multiple sources, each are required for different scenarios:
+   * - `java.class.path` system property
+   * - dependency artifacts as passed via (command-line) configuration
+   * - jars from current class loader (recursively)
+   *
+   * To have reproducable results, we order the classpath entries. This may interfere with the user's deliberate choice
+   * of order, but since we need to concatenate the classpath from different sources, the user can't really depend on
+   * the order anyway.
+   */
+  def build(config: Config, quiet: Boolean = false): String = {
+    val entries = Seq.newBuilder[String]
+    System.getProperty("java.class.path").split(pathSeparator).foreach(entries.addOne)
+
+    val fromDependencies = dependencyArtifacts(config)
+    fromDependencies.foreach(file => entries.addOne(file.toString))
+    if (fromDependencies.nonEmpty && !quiet) {
+      println(s"resolved dependencies - adding ${fromDependencies.size} artifact(s) to classpath - to list them, enable verbose mode")
+      if (verboseEnabled(config)) fromDependencies.foreach(println)
+    }
+
+    jarsFromClassLoaderRecursively(classOf[replpp.ReplDriver].getClassLoader)
+      .foreach(url => entries.addOne(url.getPath))
+
+    /** Important: we absolutely have to make sure this ends with a `pathSeparator`.
+     * Otherwise, the last entry is lost somewhere down the line. I'm still debugging where exactly, but it looks
+     * like somewhere in dotty. Will report upstream once I figured it out, but for now it doesn't harm to add a
+     * pathseparator at the end.
+     */
+    entries.result().distinct.sorted.mkString(pathSeparator, pathSeparator, pathSeparator)
+  }
+
+  private def dependencyArtifacts(config: Config): Seq[Path] = {
+    val scriptLines = config.scriptFile.map { path =>
+      Using.resource(Source.fromFile(path.toFile))(_.getLines.toSeq)
+    }.getOrElse(Seq.empty)
+    val allLines = allPredefLines(config) ++ scriptLines
+
+    val resolvers = config.resolvers ++ UsingDirectives.findResolvers(allLines)
+    val allDependencies = config.dependencies ++ UsingDirectives.findDeclaredDependencies(allLines)
+    Dependencies.resolve(allDependencies, resolvers, verboseEnabled(config)).get
+  }
+
+  private def jarsFromClassLoaderRecursively(classLoader: ClassLoader): Seq[URL] = {
+    classLoader match {
+      case cl: java.net.URLClassLoader =>
+        jarsFromClassLoaderRecursively(cl.getParent) ++ cl.getURLs
+      case _ =>
+        Seq.empty
+    }
+  }
+
+}

--- a/core/src/main/scala/replpp/util/ClasspathHelper.scala
+++ b/core/src/main/scala/replpp/util/ClasspathHelper.scala
@@ -60,19 +60,15 @@ object ClasspathHelper {
     dependencyInfos
       .groupMap(dep => (dep.organisation, dep.name))(dep => (dep.jar, Version(dep.version.getOrElse("0"))))
       .map { case ((organisation, name), jars) =>
-        if (jars.size == 1) {
-          jars.head._1
-        } else {
-          // choose the jar with the highest version
-          val result = jars.maxBy { case (_, version) => version } match {
-            case (jar, _) => jar
-          }
-          if (jars.size > 1) {
-            println(s"found ${jars.size} alternatives for organisation=${organisation.getOrElse("")} and name=${name.getOrElse("")}")
-            println(s"-> using the jar with the highest version: $result")
-          }
-          result
+        // choose the jar with the highest version
+        val result = jars.maxBy { case (_, version) => version } match {
+          case (jar, _) => jar
         }
+        if (jars.size > 1) {
+          println(s"found ${jars.size} alternatives for organisation=${organisation.getOrElse("")} and name=${name.getOrElse("")}")
+          println(s"-> using the jar with the highest version: $result")
+        }
+        result
     }.toSeq
   }
 

--- a/core/src/main/scala/replpp/util/ClasspathHelper.scala
+++ b/core/src/main/scala/replpp/util/ClasspathHelper.scala
@@ -3,9 +3,12 @@ package util
 
 import replpp.Config
 
+import java.io.ByteArrayInputStream
 import java.net.URL
 import java.io.File.pathSeparator
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
+import java.util.Map.entry
+import scala.annotation.nowarn
 import scala.io.Source
 import scala.util.Using
 
@@ -28,6 +31,33 @@ object ClasspathHelper {
     createAsSeq(config, quiet).mkString(pathSeparator, pathSeparator, pathSeparator)
   }
 
+  // TODO drop
+  def main(args: Array[String]): Unit = {
+    import java.util.jar.Attributes.Name
+    import java.util.jar.Manifest
+    import scala.jdk.CollectionConverters.*
+
+    val additionalDep = args.head
+    createAsSeq(Config(dependencies = Seq(additionalDep))).foreach { jar =>
+      //    val file = Paths.get("/home/mp/.cache/coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/ammonite_2.13.0/2.5.8/ammonite_2.13.0-2.5.8.jar")
+      val file = Paths.get(jar)
+      val manifestBytes = readFileFromZip(file, "META-INF/MANIFEST.MF")
+      val manifest = new Manifest(new ByteArrayInputStream(manifestBytes))
+      val entries = manifest.getMainAttributes.asScala
+
+      @nowarn
+      val organisationMaybe = entries.get(Name.IMPLEMENTATION_VENDOR).orElse(entries.get(Name.IMPLEMENTATION_VENDOR_ID)).map(_.toString)
+      val nameMaybe = entries.get(Name.IMPLEMENTATION_TITLE).orElse(entries.get(new Name("Automatic-Module-Name"))).orElse(entries.get(new Name("Bundle-SymbolicName"))).map(_.toString)
+      val versionMaybe = entries.get(Name.IMPLEMENTATION_VERSION).orElse(entries.get(new Name("Bundle-Version"))).map(_.toString)
+
+      case class JarWithManifestInfo(path: Path, organisation: Option[String], name: Option[String], version: Option[String])
+
+      val ctx = JarWithManifestInfo(file, organisationMaybe, nameMaybe, versionMaybe)
+      println(ctx)
+    }
+
+  }
+
   protected[util] def createAsSeq(config: Config, quiet: Boolean = false): Seq[String] = {
     val entries = Seq.newBuilder[String]
     System.getProperty("java.class.path").split(pathSeparator).foreach(entries.addOne)
@@ -45,8 +75,15 @@ object ClasspathHelper {
     onlyHighestVersionForEachJar(entries.result()).sorted
   }
 
-  /** for each organisation/name tuple: filter out anything but the highest version */
-  private[util] def onlyHighestVersionForEachJar(entries: Seq[String]): Seq[String] = ???
+  /**
+   * Goal: for each organisation/name tuple: filter out anything but the highest version. This is to ensure we don't have jars with different versions on the classpath.
+   * Problem: since we don't only get the jars via maven coordinates, but also inherit from existing classpath entries, all we have is a list of jars.
+   * The best solution is probably to use separate classloaders for the REPL itself and the code that's executed within. Similar to what ammonite does..
+   * In the interim, we use this hack as a semi-best-effort basis: group by the information in their manifests.  */
+  private[util] def onlyHighestVersionForEachJar(entries: Seq[String]): Seq[String] = {
+//    ???
+    entries
+  }
 
   private[util] def dependencyArtifacts(config: Config): Seq[Path] = {
     val scriptLines = config.scriptFile.map { path =>

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -29,8 +29,8 @@ package object util {
     Files.deleteIfExists(path)
   }
 
-  def readFileFromZip(zipFile: Path, fileName: String): Array[Byte] = {
-    Using.resource(FileSystems.newFileSystem(zipFile, null)) { fileSystem =>
+  def readFileFromZip(zipFile: Path, fileName: String): Try[Array[Byte]] = {
+    Using(FileSystems.newFileSystem(zipFile, null)) { fileSystem =>
       Files.readAllBytes(fileSystem.getPath(fileName))
     }
   }

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -1,6 +1,6 @@
 package replpp
 
-import java.nio.file.{Files, Path}
+import java.nio.file.{FileSystems, Files, Path}
 import scala.collection.immutable.Seq
 import scala.io.Source
 import scala.jdk.CollectionConverters.*
@@ -27,6 +27,12 @@ package object util {
       Files.list(path).forEach(deleteRecursively)
 
     Files.deleteIfExists(path)
+  }
+
+  def readFileFromZip(zipFile: Path, fileName: String): Array[Byte] = {
+    Using.resource(FileSystems.newFileSystem(zipFile, null)) { fileSystem =>
+      Files.readAllBytes(fileSystem.getPath(fileName))
+    }
   }
 
   def colorise(value: String, color: fansi.EscapeAttr)(using colors: Colors): String = {

--- a/core/src/test/scala/replpp/util/ClasspathHelperTests.scala
+++ b/core/src/test/scala/replpp/util/ClasspathHelperTests.scala
@@ -1,0 +1,51 @@
+package replpp.util
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import replpp.Config
+
+import java.io.File.pathSeparator
+import java.io.FileInputStream
+import java.net.URI
+import java.nio.file.Files
+
+class ClasspathHelperTests extends AnyWordSpec with Matchers {
+
+  "basic generation" in {
+    ClasspathHelper.createAsSeq(Config()).size should be > 2
+    // exact content depends on test run environment, since the current classpath is included as well
+  }
+
+  "must start and end with pathSeparator" in {
+    // to circumvent a flakiness that caused much headaches
+    val cp = ClasspathHelper.create(Config())
+    cp should startWith(pathSeparator)
+    cp should endWith(pathSeparator)
+  }
+
+  "resolves dependencies" when {
+    "declared in config" in {
+      val deps = ClasspathHelper.dependencyArtifacts(Config(dependencies = Seq(
+        "org.scala-lang:scala-library:2.13.10",
+        "org.scala-lang::scala3-library:3.3.0",
+      )))
+      deps.size shouldBe 2
+
+      assert(deps.find(_.endsWith("scala3-library_3-3.3.0.jar")).isDefined)
+      assert(deps.find(_.endsWith("scala-library-2.13.10.jar")).isDefined)
+    }
+
+    "declared in scriptFile" in {
+      val deps = ClasspathHelper.dependencyArtifacts(Config(scriptFile = Some(os.temp(
+        "//> using dep com.michaelpollmeier::colordiff:0.36"
+      ).toNIO)))
+      deps.size shouldBe 4
+
+      assert(deps.find(_.endsWith("colordiff_3-0.36.jar")).isDefined)
+      assert(deps.find(_.endsWith("scala3-library_3-3.3.0.jar")).isDefined)
+      assert(deps.find(_.endsWith("diffutils-1.3.0.jar")).isDefined)
+      assert(deps.find(_.endsWith("scala-library-2.13.10.jar")).isDefined)
+    }
+  }
+
+}

--- a/core/src/test/scala/replpp/util/ClasspathHelperTests.scala
+++ b/core/src/test/scala/replpp/util/ClasspathHelperTests.scala
@@ -11,6 +11,13 @@ import java.nio.file.Files
 
 class ClasspathHelperTests extends AnyWordSpec with Matchers {
 
+  "TODO foo bar" in {
+    val deps = ClasspathHelper.createAsSeq(Config(dependencies = Seq(
+      "org.scala-lang:scala-library:2.13.10",
+      "org.scala-lang::scala3-library:3.3.0",
+    ))).foreach(println)
+  }
+
   "basic generation" in {
     ClasspathHelper.createAsSeq(Config()).size should be > 2
     // exact content depends on test run environment, since the current classpath is included as well

--- a/core/src/test/scala/replpp/util/ClasspathHelperTests.scala
+++ b/core/src/test/scala/replpp/util/ClasspathHelperTests.scala
@@ -3,20 +3,14 @@ package replpp.util
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import replpp.Config
+import replpp.util.ClasspathHelper.JarWithManifestInfo
 
 import java.io.File.pathSeparator
 import java.io.FileInputStream
 import java.net.URI
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 
 class ClasspathHelperTests extends AnyWordSpec with Matchers {
-
-  "TODO foo bar" in {
-    val deps = ClasspathHelper.createAsSeq(Config(dependencies = Seq(
-      "org.scala-lang:scala-library:2.13.10",
-      "org.scala-lang::scala3-library:3.3.0",
-    ))).foreach(println)
-  }
 
   "basic generation" in {
     ClasspathHelper.createAsSeq(Config()).size should be > 2
@@ -55,4 +49,29 @@ class ClasspathHelperTests extends AnyWordSpec with Matchers {
     }
   }
 
+  "picks highest version for each organization/name tuple (from the jar manifests)" in {
+    val noManifest = Paths.get("no-manifest-info.jar")
+    val name0 = Paths.get("only-name.jar")
+    val org1Name1WithVersion1 = Paths.get("org1Name1WithVersion1.jar")
+    val org1Name1WithVersion2 = Paths.get("org1Nme1WithVersion2.jar")
+    val org2Name2WithVersion1 = Paths.get("org2Name2WithVersion1.jar")
+    val org2Name2WithVersion2 = Paths.get("org2Name2WithVersion2.jar")
+    val org2Name2WithVersion3 = Paths.get("org2Name2WithVersion3.jar")
+    ClasspathHelper.onlyHighestVersionForEachJar(Seq(
+      JarWithManifestInfo(noManifest, organisation = None, name = None, version = None),
+      JarWithManifestInfo(name0, organisation = None, name = Some("name0"), version = None),
+
+      JarWithManifestInfo(org1Name1WithVersion1, organisation = Some("org1"), name = Some("name1"), version = Some("1.0.0")),
+      JarWithManifestInfo(org1Name1WithVersion2, organisation = Some("org1"), name = Some("name1"), version = Some("1.0.1")),
+
+      JarWithManifestInfo(org2Name2WithVersion1, organisation = Some("org2"), name = Some("name2"), version = None),
+      JarWithManifestInfo(org2Name2WithVersion2, organisation = Some("org2"), name = Some("name2"), version = Some("2.0.0")),
+      JarWithManifestInfo(org2Name2WithVersion3, organisation = Some("org2"), name = Some("name2"), version = Some("2.0.0-RC3")),
+    )).sorted shouldBe Seq(
+      noManifest,
+      name0,
+      org1Name1WithVersion2,
+      org2Name2WithVersion2
+    ).sorted
+  }
 }

--- a/shaded-libs/src/main/scala/replpp/shaded/coursier/core/Version.scala
+++ b/shaded-libs/src/main/scala/replpp/shaded/coursier/core/Version.scala
@@ -1,0 +1,250 @@
+package replpp.shaded
+package coursier.core
+
+
+import scala.annotation.tailrec
+
+/** Used internally by Resolver.
+  *
+  * Same kind of ordering as
+  * aether-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
+  */
+case class Version(repr: String) extends Ordered[Version] {
+  lazy val items: Vector[Version.Item] = Version.items(repr)
+  def compare(other: Version)          = Version.listCompare(items, other.items)
+  def isEmpty                          = items.forall(_.isEmpty)
+}
+
+object Version {
+
+  implicit class RichChar(val c: Char) extends AnyVal {
+    private def between(c: Char, lower: Char, upper: Char) = lower <= c && c <= upper
+
+    def letterOrDigit: Boolean =
+      between(c, '0', '9') || letter
+    def letter: Boolean = between(c, 'a', 'z') || between(c, 'A', 'Z')
+  }
+
+  private[coursier] val zero = Version("0")
+
+  sealed abstract class Item extends Ordered[Item] {
+    def compare(other: Item): Int =
+      (this, other) match {
+        case (a: Number, b: Number)       => a.value.compare(b.value)
+        case (a: BigNumber, b: BigNumber) => a.value.compare(b.value)
+        case (a: Number, b: BigNumber)    => -b.value.compare(a.value)
+        case (a: BigNumber, b: Number)    => a.value.compare(b.value)
+        case (a: Tag, b: Tag)             => a.compareTag(b)
+        case _ =>
+          val rel0 = compareToEmpty
+          val rel1 = other.compareToEmpty
+
+          if (rel0 == rel1) order.compare(other.order)
+          else rel0.compare(rel1)
+      }
+
+    def order: Int
+    def isEmpty: Boolean    = compareToEmpty == 0
+    def compareToEmpty: Int = 1
+  }
+
+  sealed abstract class Numeric extends Item {
+    def repr: String
+    def next: Numeric
+  }
+  case class Number(value: Int) extends Numeric {
+    val order                   = 0
+    def next: Number            = Number(value + 1)
+    def repr: String            = value.toString
+    override def compareToEmpty = value.compare(0)
+  }
+  case class BigNumber(value: BigInt) extends Numeric {
+    val order                   = 0
+    def next: BigNumber         = BigNumber(value + 1)
+    def repr: String            = value.toString
+    override def compareToEmpty = value.compare(0)
+  }
+
+  /** Tags represent prerelease tags, typically appearing after - for SemVer compatible versions.
+    */
+  case class Tag(value: String) extends Item {
+    val order              = -1
+    private val otherLevel = -5
+    lazy val level: Int =
+      value match {
+        case "ga" | "final" | "" => 0 // 1.0.0 equivalent
+        case "snapshot"          => -1
+        case "rc" | "cr"         => -2
+        case "beta" | "b"        => -3
+        case "alpha" | "a"       => -4
+        case "dev"               => -6
+        case "sp" | "bin"        => 1
+        case _                   => otherLevel
+      }
+
+    override def compareToEmpty = level.compare(0)
+    def isPreRelease: Boolean   = level < 0
+    def compareTag(other: Tag): Int = {
+      val levelComp = level.compare(other.level)
+      if (levelComp == 0 && level == otherLevel) value.compareToIgnoreCase(other.value)
+      else levelComp
+    }
+  }
+  case class BuildMetadata(value: String) extends Item {
+    val order                   = 1
+    override def compareToEmpty = 0
+  }
+
+  case object Min extends Item {
+    val order                   = -8
+    override def compareToEmpty = -1
+  }
+  case object Max extends Item {
+    val order = 8
+  }
+
+  val empty = Number(0)
+
+  object Tokenizer {
+    sealed abstract class Separator
+    case object Dot        extends Separator
+    case object Hyphen     extends Separator
+    case object Underscore extends Separator
+    case object Plus       extends Separator
+    case object None       extends Separator
+
+    def apply(str: String): (Item, LazyList[(Separator, Item)]) = {
+      def parseItem(s: LazyList[Char], prev: Option[Separator]): (Item, LazyList[Char]) =
+        if (s.isEmpty) (empty, s)
+        else if (s.head.isDigit) {
+          def digits(b: StringBuilder, s: LazyList[Char]): (String, LazyList[Char]) =
+            if (s.isEmpty || !s.head.isDigit) (b.result(), s)
+            else digits(b += s.head, s.tail)
+
+          val (digits0, rem) = digits(new StringBuilder, s)
+          val item =
+            if (digits0.length >= 10) BigNumber(BigInt(digits0))
+            else Number(digits0.toInt)
+
+          (item, rem)
+        }
+        else if (s.head.letter) {
+          def letters(b: StringBuilder, s: LazyList[Char]): (String, LazyList[Char]) =
+            if (s.isEmpty || !s.head.letter)
+              (b.result().toLowerCase, s) // not specifying a Locale (error with scala js)
+            else
+              letters(b += s.head, s.tail)
+
+          val (letters0, rem) = letters(new StringBuilder, s)
+          val item = letters0 match {
+            case "x" if prev == Some(Dot) => Max
+            case "min"                    => Min
+            case "max"                    => Max
+            case _                        => Tag(letters0)
+          }
+          (item, rem)
+        }
+        else {
+          val (sep, _) = parseSeparator(s)
+          (prev, sep) match {
+            case (_, None) =>
+              def other(b: StringBuilder, s: LazyList[Char]): (String, LazyList[Char]) =
+                if (s.isEmpty || s.head.isLetterOrDigit || parseSeparator(s)._1 != None)
+                  (b.result().toLowerCase, s) // not specifying a Locale (error with scala js)
+                else
+                  other(b += s.head, s.tail)
+
+              val (item, rem0) = other(new StringBuilder, s)
+              // treat .* as .max
+              if (prev == Some(Dot) && item == "*") (Max, rem0)
+              else (Tag(item), rem0)
+            // treat .+ as .max
+            case (Some(Dot), Plus) => (Max, s)
+            case _                 => (empty, s)
+          }
+        }
+
+      def parseSeparator(s: LazyList[Char]): (Separator, LazyList[Char]) = {
+        assert(s.nonEmpty)
+
+        s.head match {
+          case '.' => (Dot, s.tail)
+          case '-' => (Hyphen, s.tail)
+          case '_' => (Underscore, s.tail)
+          case '+' => (Plus, s.tail)
+          case _   => (None, s)
+        }
+      }
+
+      def helper(s: LazyList[Char]): LazyList[(Separator, Item)] =
+        if (s.isEmpty) LazyList.empty
+        else {
+          val (sep, rem0) = parseSeparator(s)
+          sep match {
+            case Plus =>
+              LazyList((sep, BuildMetadata(rem0.mkString)))
+            case _ =>
+              val (item, rem) = parseItem(rem0, Some(sep))
+              (sep, item) #:: helper(rem)
+          }
+        }
+
+      val (first, rem) = parseItem(str.to(LazyList), scala.None)
+      (first, helper(rem))
+    }
+  }
+
+  def isNumeric(item: Item) = item match { case _: Numeric => true; case _ => false }
+  private def isNumericOrMinMax(item: Item): Boolean =
+    item match {
+      case _: Numeric | Min | Max => true
+      case _                      => false
+    }
+  def isBuildMetadata(item: Item) = item match { case _: BuildMetadata => true; case _ => false }
+
+  def items(repr: String): Vector[Item] = {
+    val (first, tokens) = Tokenizer(repr)
+    first +: tokens.toVector.map(_._2)
+  }
+
+  // before comparing two versions pad the number parts to the equal number of digits
+  // for example, 1-ga, and 1.0.0 comparison will be adjusted first to 1.0.0-ga and 1.0.0.
+  def listCompare(first0: Vector[Item], second0: Vector[Item]): Int = {
+    // Semver § 10: two versions that differ only in the build metadata, have the same precedence.
+    val first  = first0.filterNot(isBuildMetadata)
+    val second = second0.filterNot(isBuildMetadata)
+
+    def padNum(xs: Vector[Item], original: Int, next: Int): Vector[Item] = {
+      val (before, after) = xs.splitAt(original)
+      before ++ Vector.fill(next - original)(empty) ++ after
+    }
+    val num1 = first.takeWhile(isNumericOrMinMax)
+    val num2 = second.takeWhile(isNumericOrMinMax)
+    (num1.size, num2.size) match {
+      case (x, y) if x == y =>
+        listCompare0(first, second)
+      case (x, y) if x > y =>
+        listCompare0(first, padNum(second, y, x))
+      case (x, y) if x < y =>
+        listCompare0(padNum(first, x, y), second)
+    }
+  }
+
+  @tailrec
+  private def listCompare0(first: Vector[Item], second: Vector[Item]): Int =
+    if (first.isEmpty && second.isEmpty) 0
+    else if (first.isEmpty) {
+      assert(second.nonEmpty)
+      -second.dropWhile(_.isEmpty).headOption.fold(0)(_.compareToEmpty)
+    }
+    else if (second.isEmpty) {
+      assert(first.nonEmpty)
+      first.dropWhile(_.isEmpty).headOption.fold(0)(_.compareToEmpty)
+    }
+    else {
+      val rel = first.head.compare(second.head)
+      if (rel == 0) listCompare0(first.tail, second.tail)
+      else rel
+    }
+
+}


### PR DESCRIPTION
Goal: for each organisation/name tuple: filter out anything but the highest version. This is to ensure we don't have jars with different versions on the classpath.
Problem: since we don't only get the jars via maven coordinates, but also inherit from existing classpath entries, all we have is a list of jars.
The best solution is probably to use separate classloaders for the REPL itself and the code that's executed within. Similar to what ammonite does..
In the interim, we use this hack as a semi-best-effort basis: group by the information in their manifests.

Adds coursier.core.Version as a shaded dependency (incl. import instructions).