### PR TITLE
rendering: when a string contains `\`, automatically change to `"""`

### DIFF
--- a/core/src/main/scala/replpp/PPrinter.scala
+++ b/core/src/main/scala/replpp/PPrinter.scala
@@ -3,7 +3,6 @@ package replpp
 import replpp.shaded.fansi
 import replpp.shaded.pprint
 import replpp.shaded.pprint.{PPrinter, Renderer, Result, Tree, Truncated}
-import scala.util.matching.Regex
 
 object PPrinter {
   private var pprinter: pprint.PPrinter = null

--- a/core/src/test/scala/replpp/PPrinterTests.scala
+++ b/core/src/test/scala/replpp/PPrinterTests.scala
@@ -60,7 +60,6 @@ class PPrinterTests extends AnyWordSpec with Matchers {
   }
 
   "render strings with string escapes using triple quotes" in {
-    // TODO suggest as PR in fansi upstream - once it's in, this test can be dropped
     PPrinter("""a\b""", nocolors = true) shouldBe "     \"\"\"a\\b\"\"\"    ".trim
   }
 

--- a/core/src/test/scala/replpp/PPrinterTests.scala
+++ b/core/src/test/scala/replpp/PPrinterTests.scala
@@ -59,6 +59,11 @@ class PPrinterTests extends AnyWordSpec with Matchers {
     )
   }
 
+  "render strings with string escapes using triple quotes" in {
+    // TODO suggest as PR in fansi upstream - once it's in, this test can be dropped
+    PPrinter("""a\b""", nocolors = true) shouldBe "     \"\"\"a\\b\"\"\"    ".trim
+  }
+
   "don't error on invalid ansi encodings" in {
     val invalidAnsi = Files.readString(ProjectRoot.relativise("core/src/test/resources/invalid-ansi.txt"))
     Try {

--- a/shaded-libs/src/main/scala/replpp/shaded/pprint/Walker.scala
+++ b/shaded-libs/src/main/scala/replpp/shaded/pprint/Walker.scala
@@ -67,7 +67,8 @@ abstract class Walker{
       case x: Float => Tree.Literal(x.toString + "F")
       case x: Double => Tree.Literal(x.toString)
       case x: String =>
-        if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
+        // MP: adapted here: added ` || c == '\\'`
+        if (x.exists(c => c == '\n' || c == '\r' || c == '\\')) Tree.Literal("\"\"\"" + x + "\"\"\"")
         else Tree.Literal(Util.literalize(x, escapeUnicode))
 
       case x: Symbol => Tree.Literal("'" + x.name)

--- a/shaded-libs/src/main/scala/replpp/shaded/pprint/Walker.scala
+++ b/shaded-libs/src/main/scala/replpp/shaded/pprint/Walker.scala
@@ -68,6 +68,7 @@ abstract class Walker{
       case x: Double => Tree.Literal(x.toString)
       case x: String =>
         // MP: adapted here: added ` || c == '\\'`
+        // MP: upstream PR: https://github.com/com-lihaoyi/PPrint/pull/110
         if (x.exists(c => c == '\n' || c == '\r' || c == '\\')) Tree.Literal("\"\"\"" + x + "\"\"\"")
         else Tree.Literal(Util.literalize(x, escapeUnicode))
 


### PR DESCRIPTION
So that we don't need to escape it and it can be easily copy-pasted.

Old behaviour:
```scala
scala> """foo\bar"""
val res0: String = "foo\\bar"
```

New behaviour:
```scala
scala> """foo\bar"""
val res0: String = """foo\bar"""
```

Will suggest to fansi upstream.
Special thanks to @maltek for noticing and suggesting.