### PR TITLE
fix bug in import file directives

### DIFF
--- a/core/src/main/scala/replpp/UsingDirectives.scala
+++ b/core/src/main/scala/replpp/UsingDirectives.scala
@@ -12,7 +12,7 @@ object UsingDirectives {
   def findImportedFilesRecursively(path: Path, visited: Set[Path] = Set.empty): Seq[Path] = {
     val rootDir: Path =
       if (Files.isDirectory(path)) path
-      else path.getParent
+      else path.toAbsolutePath.getParent
 
     val importedFiles = findImportedFiles(util.linesFromFile(path), rootDir)
     val recursivelyImportedFiles = importedFiles.filterNot(visited.contains).flatMap { file =>


### PR DESCRIPTION
the below fails without this change:
```
echo 'val bar = foo' > myScript.sc
echo '//> using file myScript.sc' > test-simple.sc

./srp --script test-simple.sc
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.resolve(java.nio.file.Path)" because "base" is null
```