### PR TITLE
interactive shell: if imported file doesn't exist, report an error but don't fail hard

### DIFF
--- a/core/src/main/scala/replpp/ReplDriverBase.scala
+++ b/core/src/main/scala/replpp/ReplDriverBase.scala
@@ -11,11 +11,12 @@ import dotty.tools.dotc.core.{Contexts, MacroClassLoader, Mode, TyperState}
 import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation}
 import dotty.tools.repl.*
 import org.jline.reader.*
+import replpp.shaded.fansi
 
 import java.io.PrintStream
 import java.lang.System.lineSeparator
 import java.net.URL
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import javax.naming.InitialContext
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -44,9 +45,13 @@ abstract class ReplDriverBase(args: Array[String],
       // now read and interpret the given file
       val pathStr = line.trim.drop(UsingDirectives.FileDirective.length)
       val path = resolveFile(currentFile, pathStr)
-      val linesFromFile = util.linesFromFile(path)
-      println(s"> importing $path (${linesFromFile.size} lines)")
-      currentState = interpretInput(linesFromFile, currentState, path)
+      if (Files.exists(path)) {
+        val linesFromFile = util.linesFromFile(path)
+        println(s"> importing $path (${linesFromFile.size} lines)")
+        currentState = interpretInput(linesFromFile, currentState, path)
+      } else {
+        System.err.println(util.colorise(s"Warning: given file `$path` does not exist.", fansi.Color.Red))
+      }
     }
 
     for (line <- lines.iterator) {

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -5,6 +5,7 @@ import scala.collection.immutable.Seq
 import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.util.{Try, Using}
+import replpp.shaded.fansi
 
 package object util {
 
@@ -26,6 +27,13 @@ package object util {
       Files.list(path).forEach(deleteRecursively)
 
     Files.deleteIfExists(path)
+  }
+
+  def colorise(value: String, color: fansi.EscapeAttr)(using colors: Colors): String = {
+    colors match {
+      case Colors.BlackWhite => value
+      case Colors.Default => color(value).render
+    }
   }
 
 }


### PR DESCRIPTION
before:
```
scala> //> using file nothere.sc
Exception in thread "main" java.io.FileNotFoundException: /home/mp/Projects/scala-repl-pp/./nothere.sc (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:158)
        at scala.io.Source$.fromFile(Source.scala:94)
        at scala.io.Source$.fromFile(Source.scala:79)
        at replpp.util.package$.linesFromFile(package.scala:22)
        at replpp.ReplDriverBase.handleImportFileDirective$1(ReplDriverBase.scala:47)
        at replpp.ReplDriverBase.interpretInput$$anonfun$1(ReplDriverBase.scala:54)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:575)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:573)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1300)
        at replpp.ReplDriverBase.interpretInput(ReplDriverBase.scala:57)
        at replpp.ReplDriver.loop$1$$anonfun$1(ReplDriver.scala:35)
        at scala.util.Try$.apply(Try.scala:210)
        at replpp.ReplDriver.loop$1(ReplDriver.scala:36)
        at replpp.ReplDriver.runUntilQuit$$anonfun$2(ReplDriver.scala:52)
        at replpp.DottyReplDriver.withRedirectedOutput(DottyReplDriver.scala:187)
        at replpp.DottyReplDriver.runBody$$anonfun$1(DottyReplDriver.scala:161)
        at dotty.tools.runner.ScalaClassLoader$.asContext(ScalaClassLoader.scala:80)
        at replpp.DottyReplDriver.runBody(DottyReplDriver.scala:161)
        at replpp.ReplDriver.runUntilQuit(ReplDriver.scala:53)
        at replpp.InteractiveShell$.run(InteractiveShell.scala:39)
        at replpp.Main$.main(Main.scala:12)
        at replpp.Main.main(Main.scala)

```

after:
```scala> //> using file nothere.sc
Warning: given file `/home/mp/Projects/scala-repl-pp/./nothere.sc` does not exist.
```