### PR TITLE
fix import file directive for interactive repl

### DIFF
--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -88,11 +88,17 @@ package object replpp {
     * resolve absolute or relative paths to an absolute path
     * - if given pathStr is an absolute path, just take that
     * - if it's a relative path, use given base path to resolve it to an absolute path
+    * - if the base path is a file, take it's root directory - anything else doesn't make any sense.
     */
   def resolveFile(base: Path, pathStr: String): Path = {
     val path = Paths.get(pathStr)
     if (path.isAbsolute) path
-    else base.resolve(path)
+    else {
+      val base0 =
+        if (Files.isDirectory(base)) base
+        else base.getParent
+      base0.resolve(path)
+    }
   }
 
 }


### PR DESCRIPTION
fixes the following import:
```
scala> //> using file main.sc
> importing /home/mp/Projects/scala-repl-pp/./testscript/main.sc (2 lines)
Warning: given file `/home/mp/Projects/scala-repl-pp/./testscript/main.sc/helper.sc` does not exist.
```

where
```
$ cat main.sc
//> using file helper.sc
println(foo)

$ cat helper.sc
val foo = 42
```