### PR TITLE
allow to lookup current terminal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Prerequisite: jdk11+
   * [Importing additional script files interactively](#importing-additional-script-files-interactively)
   * [Rendering of output](#rendering-of-output)
   * [Exiting the REPL](#exiting-the-repl)
+  * [Looking up the current terminal width](#looking-up-the-current-terminal-width)
 - [Scripting](#scripting)
   * [Simple "Hello world" script](#simple-hello-world-script)
   * [Predef file(s) used in script](#predef-files-used-in-script)
@@ -58,7 +59,6 @@ Prerequisite: jdk11+
   * [Updating the Scala version](#updating-the-scala-version)
   * [Updating the shaded libraries](#updating-the-shaded-libraries)
 - [Fineprint](#fineprint)  
-  
   
   
 ## Benefits over / comparison with
@@ -241,6 +241,14 @@ Captured interrupt signal `INT` - if you want to kill the REPL, press Ctrl-c aga
 $
 ```
 Context: we'd prefer to cancel the long-running operation, but that's not so easy on the JVM.
+
+### Looking up the current terminal width
+In case you want to adjust your output rendering to the available terminal size, you can look it up:
+
+```
+scala> replpp.util.terminalWidth
+val res0: util.Try[Int] = Success(value = 202)
+```
 
 ## Scripting
 

--- a/core/src/main/scala/replpp/Config.scala
+++ b/core/src/main/scala/replpp/Config.scala
@@ -267,7 +267,11 @@ object Config {
       ".*scala3-library_3.*",
       ".*scala-library.*",
       ".*tasty-core_3.*",
-      ".*scala-asm.*"
+      ".*scala-asm.*",
+
+      // for replpp.util.terminalWidth
+      ".*jline-terminal-.*",
+      ".*net.java.dev.jna.jna.*",
     )
   }
 }

--- a/core/src/main/scala/replpp/package.scala
+++ b/core/src/main/scala/replpp/package.scala
@@ -1,14 +1,9 @@
 import replpp.util.{ClasspathHelper, linesFromFile}
 
 import java.io.File
-import java.io.File.pathSeparator
 import java.lang.System.lineSeparator
-import java.net.URL
 import java.nio.file.{Files, Path, Paths}
-import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.io.Source
-import scala.util.Using
 
 package object replpp {
   enum Colors { case BlackWhite, Default }
@@ -23,6 +18,7 @@ package object replpp {
 
   lazy val globalPredefFile = home.resolve(".scala-repl-pp.sc")
   lazy val globalPredefFileMaybe = Option(globalPredefFile).filter(Files.exists(_))
+
   private[replpp] def DefaultPredefLines(using colors: Colors) = {
     val colorsImport = colors match {
       case Colors.BlackWhite => "replpp.Colors.BlackWhite"
@@ -33,6 +29,7 @@ package object replpp {
       s"given replpp.Colors = $colorsImport"
     )
   }
+
   private[replpp] def DefaultPredef(using Colors) = DefaultPredefLines.mkString(lineSeparator)
 
   /** verbose mode can either be enabled via the config, or the environment variable `SCALA_REPL_PP_VERBOSE=true` */

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -45,15 +45,7 @@ package object util {
   /** Lookup the current terminal width - useful e.g. if you want to render something using the maximum space available.
     * Uses jline-jna, which therefor needs to be in the repl's classpath, which is why it's listed in
     * {{{replpp.Config.ForClasspath.DefaultInheritClasspathIncludes}}} */
-  def terminalWidth: Try[Int] = {
-    Try {
-      if (scala.util.Properties.isLinux)
-        org.jline.terminal.impl.jna.linux.LinuxNativePty.current.getSize.getColumns
-      else if (scala.util.Properties.isMac)
-        org.jline.terminal.impl.jna.osx.OsXNativePty.current.getSize.getColumns
-      else
-      throw new NotImplementedError("terminal width lookup only supported for linux and mac for now")
-    }
-  }
+  def terminalWidth: Try[Int] =
+    Using(org.jline.terminal.TerminalBuilder.terminal)(_.getWidth)
 
 }

--- a/core/src/main/scala/replpp/util/package.scala
+++ b/core/src/main/scala/replpp/util/package.scala
@@ -1,11 +1,11 @@
 package replpp
 
+import replpp.shaded.fansi
+
 import java.nio.file.{FileSystems, Files, Path}
 import scala.collection.immutable.Seq
 import scala.io.Source
-import scala.jdk.CollectionConverters.*
 import scala.util.{Try, Using}
-import replpp.shaded.fansi
 
 package object util {
 
@@ -39,6 +39,20 @@ package object util {
     colors match {
       case Colors.BlackWhite => value
       case Colors.Default => color(value).render
+    }
+  }
+
+  /** Lookup the current terminal width - useful e.g. if you want to render something using the maximum space available.
+    * Uses jline-jna, which therefor needs to be in the repl's classpath, which is why it's listed in
+    * {{{replpp.Config.ForClasspath.DefaultInheritClasspathIncludes}}} */
+  def terminalWidth: Try[Int] = {
+    Try {
+      if (scala.util.Properties.isLinux)
+        org.jline.terminal.impl.jna.linux.LinuxNativePty.current.getSize.getColumns
+      else if (scala.util.Properties.isMac)
+        org.jline.terminal.impl.jna.osx.OsXNativePty.current.getSize.getColumns
+      else
+      throw new NotImplementedError("terminal width lookup only supported for linux and mac for now")
     }
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8


### PR DESCRIPTION
* using jline3 terminal's functionality which uses jna calls
* for windows it's probably also doable by replicating what the three 
  different jline-for-windows terminal implementations do, but it seems more
  complicated and I don't have the capacity to test it all atm