### PR TITLE
script execution: adjust line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Prerequisite: jdk11+
 - [Parameters cheat sheet: the most important ones](#parameters-cheat-sheet-the-most-important-ones)
 - [FAQ](#faq)
   * [Is this an extension of the stock REPL or a fork?](#is-this-an-extension-of-the-stock-repl-or-a-fork)
-  * [Why are script line numbers incorrect?](#why-are-script-line-numbers-incorrect)
   * [Why do we ship a shaded copy of other libraries and not use dependencies?](#why-do-we-ship-a-shaded-copy-of-other-libraries-and-not-use-dependencies)
   * [Where's the cache located on disk?](#wheres-the-cache-located-on-disk)
 - [Contribution guidelines](#contribution-guidelines)
@@ -526,13 +525,6 @@ Technically it is a fork, i.e. we copied parts of the ReplDriver to make some ad
 However, semantically, srp can be considered an extension of the stock repl. We don't want to create and maintain a competing REPL implementation, 
 instead the idea is to provide a space for exploring new ideas and bringing them back into the dotty codebase. 
 [When we forked](https://github.com/mpollmeier/scala-repl-pp/commit/eb2bf9a3bed681bffa945f657ada14781c6a7a14) the stock ReplDriver, we made sure to separate the commits into bitesized chunks so we can easily rebase. The changes are clearly marked, and whenever there's a new dotty version we're bringing in the relevant changes here (`git diff 3.3.0-RC5..3.3.0-RC6 compiler/src/dotty/tools/repl/`).
-
-### Why are script line numbers incorrect?
-srp currently uses a simplistic model for predef code|files and additionally imported files, and just copies everything into one large script. That simplicity naturally comes with a few limitations, e.g. line numbers may be different from the input script(s). 
-
-A better approach would be to work with a separate compiler phase, similar to what Ammonite does. That way, we could inject all previously defined values|imports|... into the compiler, and extract all results from the compiler context. That's a goal for the future. 
-
-If there's a compilation issue, the temporary script file will not be deleted and the error output will tell you it's path, in order to help with debugging.
 
 ### Why do we ship a shaded copy of other libraries and not use dependencies?
 srp includes some small libraries (e.g. most of the com-haoyili universe) that have been copied as-is, but then moved into the `replpp.shaded` namespace. We didn't include them as regular dependencies, because repl users may want to use a different version of them, which may be incompatible with the version the repl uses. Thankfully their license is very permissive - a big thanks to the original authors! The instructions of how to (re-) import then and which versions were used are available in [import-instructions.md](shaded-libs/import-instructions.md).

--- a/core/src/main/scala/replpp/scripting/NonForkingScriptRunner.scala
+++ b/core/src/main/scala/replpp/scripting/NonForkingScriptRunner.scala
@@ -35,56 +35,21 @@ object NonForkingScriptRunner {
       commandArgs ++ parameterArgs
     }
 
-    // Predef code may include import statements... I didn't find a nice way to add them to the context of the
-    // script file, so instead we'll just write it to the beginning of the script file.
-    // That's obviously suboptimal, e.g. because it messes with the line numbers.
-    // Therefor, we'll display the temp script file name to the user and not delete it, in case the script errors.
-    val scriptContent = wrapForMainargs(Files.readString(scriptFile))
-    val predefPlusScriptFileTmp = Files.createTempFile("scala-repl-pp-script-with-predef", ".sc")
-    Files.writeString(predefPlusScriptFileTmp, scriptContent)
-
     val verboseEnabled = replpp.verboseEnabled(config)
     new ScriptingDriver(
       compilerArgs = replpp.compilerArgs(config) :+ "-nowarn",
       predefFiles = allPredefFiles(config),
-      scriptFile = predefPlusScriptFileTmp,
+      scriptFile = scriptFile,
       scriptArgs = scriptArgs.toArray,
       verbose = verboseEnabled
     ).compileAndRun() match {
       case Some(exception) =>
         System.err.println(s"error during script execution: ${exception.getMessage}")
-        System.err.println(s"note: line numbers may not be accurate - to help with debugging, the final scriptContent is at $predefPlusScriptFileTmp")
         throw exception
       case None => // no exception, i.e. all is good
         if (verboseEnabled) System.err.println(s"script finished successfully")
-        // if the script failed, we don't want to delete the temporary file which includes the predef,
-        // so that the line numbers are accurate and the user can properly debug
-        Files.deleteIfExists(predefPlusScriptFileTmp)
     }
   }
 
-  private def wrapForMainargs(scriptCode: String): String = {
-    val mainImpl =
-      if (scriptCode.contains("@main")) scriptCode
-      else
-        s"""@main def _execMain(): Unit = {
-           |  $scriptCode
-           |}
-           |""".stripMargin
-
-    s"""import replpp.shaded.mainargs
-       |import mainargs.main // intentionally shadow any potentially given @main
-       |
-       |// ScriptingDriver expects an object with a predefined name and a main entrypoint method
-       |object ${ScriptingDriver.MainClassName} {
-       |
-       |$mainImpl
-       |
-       |  def ${ScriptingDriver.MainMethodName}(args: Array[String]): Unit = {
-       |    mainargs.ParserForMethods(this).runOrExit(args.toSeq)
-       |  }
-       |}
-       |""".stripMargin
-  }
 
 }

--- a/core/src/main/scala/replpp/scripting/WrapForMainArgs.scala
+++ b/core/src/main/scala/replpp/scripting/WrapForMainArgs.scala
@@ -1,0 +1,43 @@
+package replpp.scripting
+
+/** So that we can execute the given script and potentially handle parameters, we wrap it in some code using
+ * https://github.com/com-lihaoyi/mainargs  */
+object WrapForMainArgs {
+
+  /** linesBeforeWrappedCode: allows us to adjust line numbers in error reporting... */
+  case class WrappingResult(fullScript: String, linesBeforeWrappedCode: Int)
+
+  def apply(scriptCode: String): WrappingResult = {
+    var linesBeforeWrappedCode = 0
+    val mainImpl =
+      if (scriptCode.contains("@main")) {
+        scriptCode
+      } else {
+        linesBeforeWrappedCode += 1
+        s"""@main def _execMain(): Unit = {
+           |  $scriptCode
+           |}""".stripMargin
+      }
+
+    linesBeforeWrappedCode += codeBefore.lines().count().toInt
+    val fullScript =
+      s"""$codeBefore
+         |$mainImpl
+         |
+         |  def ${ScriptingDriver.MainMethodName}(args: Array[String]): Unit = {
+         |    mainargs.ParserForMethods(this).runOrExit(args.toSeq)
+         |  }
+         |}
+         |""".stripMargin
+
+    WrappingResult(fullScript, linesBeforeWrappedCode)
+  }
+
+  private val codeBefore =
+    s"""import replpp.shaded.mainargs
+       |import mainargs.main // intentionally shadow any potentially given @main
+       |
+       |// ScriptingDriver expects an object with a predefined name and a main entrypoint method
+       |object ${ScriptingDriver.MainClassName} {""".stripMargin
+
+}

--- a/core/src/main/scala/replpp/scripting/WrapForMainArgs.scala
+++ b/core/src/main/scala/replpp/scripting/WrapForMainArgs.scala
@@ -15,7 +15,7 @@ object WrapForMainArgs {
       } else {
         linesBeforeWrappedCode += 1
         s"""@main def _execMain(): Unit = {
-           |  $scriptCode
+           |$scriptCode
            |}""".stripMargin
       }
 


### PR DESCRIPTION
before this change:
```bash
echo 'val i: Int = "Hello!"' > foo.sc
./srp --script foo.sc

executing foo.sc
-- [E007] Type Mismatch Error:
/tmp/scala-repl-pp-script-with-predef2026848595210523554.sc:8:15
8 |  val i: Int = "Hello!"
  |               ^^^^^^^^
  |               Found:    ("Hello!" : String)
  |               Required: Int
```

with this change:
```bash
echo 'val i: Int = "Hello!"' > foo.sc
./srp --script foo.sc

executing foo.sc
-- [E007] Type Mismatch Error: /tmp/wrapped-script16126559910573703929.sc:1:15 -
1 |  val i: Int = "Hello!"
  |               ^^^^^^^^
  |               Found:    ("Hello!" : String)
  |               Required: Int
```

works for most cases... not all though:
```bash
echo 'println("Hello!"' > foo.sc
./srp --script foo.sc

executing test-simple.sc
-- [E040] Syntax Error: /tmp/wrapped-script12034823679540823317.sc:3:0
---------
3 |}}
  |^
  |')' expected, but '}' found
```