### PR TITLE
don't fail if subprocess finished

### DIFF
--- a/core/src/main/scala/replpp/Operators.scala
+++ b/core/src/main/scala/replpp/Operators.scala
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Path, Paths}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Try, Using}
+import scala.util.control.NonFatal
 
 /**
  * Operators to redirect output to files or pipe them into external commands / processes,
@@ -21,6 +22,13 @@ import scala.util.{Try, Using}
  * List types (IterableOnce, java.lang.Iterable, Array, ...) are being unwrapped (only at the root level).
  * */
 object Operators {
+
+  def main(args: Array[String]): Unit = {
+    given Colors = Colors.BlackWhite
+    val value = "foo"
+    val result = value #| "cat"
+    println(result)
+  }
 
   /** output from an external command, e.g. when using `#|` */
   case class ProcessResults(stdout: String, stderr: String)
@@ -150,7 +158,7 @@ object Operators {
             }
           }
           // flush stdin, but ignore errors
-          try {stdin.flush()} catch { case t: Throwable => /*ignore*/ }
+          try {stdin.flush()} catch { case NonFatal(_) => /*ignore*/ }
         }
       }
     }

--- a/core/src/main/scala/replpp/Operators.scala
+++ b/core/src/main/scala/replpp/Operators.scala
@@ -149,6 +149,8 @@ object Operators {
                 stopped = true
             }
           }
+          // flush stdin, but ignore errors
+          try {stdin.flush()} catch { case t: Throwable => /*ignore*/ }
         }
       }
     }


### PR DESCRIPTION
e.g. the user exited `less` before all results were written...

example from joern _before_ this PR:
```
importCpg("/home/mp/tmp/cpgtesting/linux-kernel/linux6-drivers-scsi.fg")
cpg.method.name.browse
Exception in thread "less stdin thread" java.io.IOException: Broken pipe
        at java.base/java.io.FileOutputStream.writeBytes(Native Method)
        at java.base/java.io.FileOutputStream.write(FileOutputStream.java:349)
        at java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:123)
        at java.base/sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:234)
        at java.base/sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:304)
        at java.base/sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282)
        at java.base/sun.nio.cs.StreamEncoder.write(StreamEncoder.java:132)
        at java.base/java.io.OutputStreamWriter.write(OutputStreamWriter.java:205)
        at java.base/java.io.BufferedWriter.flushBuffer(BufferedWriter.java:120)
        at java.base/java.io.BufferedWriter.write(BufferedWriter.java:233)
        at replpp.Operators$$anon$1.processInput$$anonfun$1(Operators.scala:140)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

This PR silences this issue.